### PR TITLE
Fix Diaspora photo support and allow entities to have children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [unreleased]
+
+### Backwards incompatible changes
+* `Image` no longer has a `text` attribute. It is replaced by `raw_content`, the same attribute as `Post` and `Comment` have. Unlike the latter two, `Image.raw_content` is not mandatory.
+
+### Added
+* Entities can now have a children. These can be accessed using the `_children` list. Acceptable children depends on the entity. Currently, `Post`, `Comment` and `Profile` can have children of entity type `Image`. Child types are validated in the `.validate()` entity method call.
+
+### Fixed
+* Diaspora protocol `message_to_objects` method (called through inbound high level methods) now correctly parses Diaspora `<photo>` elements and creates `Image` entities from them. If they are children of status messages, they will be available through the `Post._children` list.
+
 ## [0.8.2] - 2016-10-23
 
 ### Fixed

--- a/federation/tests/entities/diaspora/test_mappers.py
+++ b/federation/tests/entities/diaspora/test_mappers.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 import pytest
 
-from federation.entities.base import Comment, Post, Reaction, Relationship, Profile, Retraction
+from federation.entities.base import (
+    Comment, Post, Reaction, Relationship, Profile, Retraction, Image
+)
 from federation.entities.diaspora.entities import (
     DiasporaPost, DiasporaComment, DiasporaLike, DiasporaRequest,
     DiasporaProfile, DiasporaRetraction
@@ -12,8 +14,8 @@ from federation.entities.diaspora.entities import (
 from federation.entities.diaspora.mappers import message_to_objects, get_outbound_entity
 from federation.tests.fixtures.payloads import (
     DIASPORA_POST_SIMPLE, DIASPORA_POST_COMMENT, DIASPORA_POST_LIKE,
-    DIASPORA_REQUEST, DIASPORA_PROFILE, DIASPORA_POST_INVALID, DIASPORA_RETRACTION
-)
+    DIASPORA_REQUEST, DIASPORA_PROFILE, DIASPORA_POST_INVALID, DIASPORA_RETRACTION,
+    DIASPORA_POST_WITH_PHOTOS)
 
 
 def mock_fill(attributes):
@@ -34,6 +36,38 @@ class TestDiasporaEntityMappersReceive(object):
         assert post.public == False
         assert post.created_at == datetime(2011, 7, 20, 1, 36, 7)
         assert post.provider_display_name == "Socialhome"
+
+    def test_message_to_objects_post_with_photos(self):
+        entities = message_to_objects(DIASPORA_POST_WITH_PHOTOS)
+        assert len(entities) == 1
+        post = entities[0]
+        assert isinstance(post, DiasporaPost)
+        photo = post._children[0]
+        assert isinstance(photo, Image)
+        assert photo.remote_path == "https://alice.diaspora.example.org/uploads/images/"
+        assert photo.remote_name == "1234.jpg"
+        assert photo.raw_content == None
+        assert photo.linked_type == "Post"
+        assert photo.linked_guid == "((guidguidguidguidguidguidguid))"
+        assert photo.height == 120
+        assert photo.width == 120
+        assert photo.guid == "((guidguidguidguidguidguidguif))"
+        assert photo.handle == "alice@alice.diaspora.example.org"
+        assert photo.public == False
+        assert photo.created_at == datetime(2011, 7, 20, 1, 36, 7)
+        photo = post._children[1]
+        assert isinstance(photo, Image)
+        assert photo.remote_path == "https://alice.diaspora.example.org/uploads/images/"
+        assert photo.remote_name == "12345.jpg"
+        assert photo.raw_content == "foobar"
+        assert photo.linked_type == "Post"
+        assert photo.linked_guid == "((guidguidguidguidguidguidguid))"
+        assert photo.height == 120
+        assert photo.width == 120
+        assert photo.guid == "((guidguidguidguidguidguidguig))"
+        assert photo.handle == "alice@alice.diaspora.example.org"
+        assert photo.public == False
+        assert photo.created_at == datetime(2011, 7, 20, 1, 36, 7)
 
     def test_message_to_objects_comment(self):
         entities = message_to_objects(DIASPORA_POST_COMMENT)

--- a/federation/tests/entities/test_base.py
+++ b/federation/tests/entities/test_base.py
@@ -25,6 +25,28 @@ class TestBaseEntityCallsValidateMethods(object):
         post.validate()
         assert post.validate_location.call_count == 1
 
+    def test_entity_calls_main_validate_methods(self):
+        post = PostFactory()
+        post._validate_required = Mock()
+        post._validate_attributes = Mock()
+        post._validate_empty_attributes = Mock()
+        post._validate_children = Mock()
+        post.validate()
+        assert post._validate_required.call_count == 1
+        assert post._validate_attributes.call_count == 1
+        assert post._validate_empty_attributes.call_count == 1
+        assert post._validate_children.call_count == 1
+
+    def test_validate_children(self):
+        post = PostFactory()
+        image = Image()
+        profile = Profile()
+        post._children = [image]
+        post._validate_children()
+        post._children = [profile]
+        with pytest.raises(ValueError):
+            post._validate_children()
+
 
 class TestGUIDMixinValidate(object):
     def test_validate_guid_raises_on_low_length(self):

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -42,6 +42,46 @@ DIASPORA_POST_SIMPLE = """<XML>
     </XML>
 """
 
+
+DIASPORA_POST_WITH_PHOTOS = """<XML>
+      <post>
+        <status_message>
+          <raw_message>((status message))</raw_message>
+          <guid>((guidguidguidguidguidguidguid))</guid>
+          <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>
+          <public>false</public>
+          <created_at>2011-07-20 01:36:07 UTC</created_at>
+          <provider_display_name>Socialhome</provider_display_name>
+          <photo>
+            <guid>((guidguidguidguidguidguidguif))</guid>
+            <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>
+            <public>false</public>
+            <created_at>2011-07-20 01:36:07 UTC</created_at>
+            <remote_photo_path>https://alice.diaspora.example.org/uploads/images/</remote_photo_path>
+            <remote_photo_name>1234.jpg</remote_photo_name>
+            <text/>
+            <status_message_guid>((guidguidguidguidguidguidguid))</status_message_guid>
+            <height>120</height>
+            <width>120</width>
+          </photo>
+          <photo>
+            <guid>((guidguidguidguidguidguidguig))</guid>
+            <diaspora_handle>alice@alice.diaspora.example.org</diaspora_handle>
+            <public>false</public>
+            <created_at>2011-07-20 01:36:07 UTC</created_at>
+            <remote_photo_path>https://alice.diaspora.example.org/uploads/images/</remote_photo_path>
+            <remote_photo_name>12345.jpg</remote_photo_name>
+            <text>foobar</text>
+            <status_message_guid>((guidguidguidguidguidguidguid))</status_message_guid>
+            <height>120</height>
+            <width>120</width>
+          </photo>
+        </status_message>
+      </post>
+    </XML>
+"""
+
+
 DIASPORA_POST_INVALID = """<XML>
       <post>
         <status_message>


### PR DESCRIPTION
Diaspora photo elements are now processed correctly. Inbound parsing has been changed to also correctly add them to created entities as children, if they happen to be embedded in status messages, for example. Entity children can be iterated using the `_children` list.

Also rename the `Image.text` attribute to `Image.raw_content` to be more consistent.

Closes #62