### PR TITLE
Made Profile.raw_content optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [unreleased]
+
+### Fixes
+* Made `Profile.raw_content` optional. This fixes validating profiles parsed from Diaspora hCard's.
+
 ## [0.9.0] - 2016-12-10
 
 ### Backwards incompatible changes

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -253,7 +253,7 @@ class Relationship(CreatedAtMixin, HandleMixin):
             ))
 
 
-class Profile(CreatedAtMixin, HandleMixin, RawContentMixin, PublicMixin, GUIDMixin):
+class Profile(CreatedAtMixin, HandleMixin, OptionalRawContentMixin, PublicMixin, GUIDMixin):
     """Represents a profile for a user."""
     name = ""
     email = ""

--- a/federation/tests/utils/test_diaspora.py
+++ b/federation/tests/utils/test_diaspora.py
@@ -115,7 +115,7 @@ class TestParseProfileFromHCard(object):
     def test_profile_is_parsed(self):
         hcard = generate_hcard(
             "diaspora",
-            hostname="https://hostname",
+            hostname="https://example.com",
             fullname="fullname",
             firstname="firstname",
             lastname="lastname",
@@ -123,19 +123,20 @@ class TestParseProfileFromHCard(object):
             photo100="photo100",
             photo50="photo50",
             searchable="true",
-            guid="guid",
+            guid="guidguidguidguid",
             public_key="public_key",
             username="username",
         )
-        profile = parse_profile_from_hcard(hcard, "username@hostname")
+        profile = parse_profile_from_hcard(hcard, "username@example.com")
         assert profile.name == "fullname"
         assert profile.image_urls == {
             "small": "photo50", "medium": "photo100", "large": "photo300"
         }
         assert profile.public == True
-        assert profile.handle == "username@hostname"
-        assert profile.guid == "guid"
+        assert profile.handle == "username@example.com"
+        assert profile.guid == "guidguidguidguid"
         assert profile.public_key == "public_key\n"
+        profile.validate()
 
 
 class TestRetrieveAndParseProfile(object):


### PR DESCRIPTION
This fixes validating profiles parsed from Diaspora hCard's.