### PR TITLE
Add receiving user guid to entity for private Diaspora payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,10 @@
 ### Added
 * New style Diaspora public payloads are now supported (see [here](https://github.com/diaspora/diaspora_federation/issues/30)). Old style payloads are still supported. Payloads are also still sent out old style.
 * Add new `Follow` base entity and support for the new Diaspora "contact" payload. The simple `Follow` maps to Diaspora contact entity with following/sharing both true or false. Sharing as a separate concept is not currently supported.
+* Added `_receiving_guid` to all entities. This is filled with `user.guid` if `user` is passed to `federation.inbound.handle_receive` and it has a `guid`. Normally in for example Diaspora, this will always be done in private payloads.
 
 ### Fixed
-* Legacy Diaspora retraction of sharing/following is now supported correctly. The end result is a `DiasporaRetraction` for entity type `Profile`.
+* Legacy Diaspora retraction of sharing/following is now supported correctly. The end result is a `DiasporaRetraction` for entity type `Profile`. Since the payload doesn't contain the receiving user for a sharing/following retraction in legacy Diaspora protocol, we store the guid of the user in the entity as `_receiving_guid`, assuming it was passed in for processing.
 
 
 ## [0.11.0] - 2017-05-08

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -13,6 +13,8 @@ class BaseEntity(object):
     _required = []
     _children = []
     _allowed_children = ()
+    # If we have a receiver for a private payload, store receiving user guid here
+    _receiving_guid = ""
     _source_protocol = ""
     _source_object = None
     _sender_key = ""

--- a/federation/inbound.py
+++ b/federation/inbound.py
@@ -23,7 +23,8 @@ def handle_receive(payload, user=None, sender_key_fetcher=None, skip_author_veri
     could actually be a different identity.
 
     :arg payload: Payload blob (str)
-    :arg user: User that will be passed to `protocol.receive` (required on private encrypted content)
+    :arg user: User that will be passed to `protocol.receive` (only required on private encrypted content)
+        MUST have a `private_key` and `guid` if given.
     :arg sender_key_fetcher: Function that accepts sender handle and returns public key (optional)
     :arg skip_author_verification: Don't verify sender (test purposes, false default)
     :returns: Tuple of sender handle, protocol name and list of entity objects
@@ -47,7 +48,7 @@ def handle_receive(payload, user=None, sender_key_fetcher=None, skip_author_veri
         raise NoSuitableProtocolFoundError()
 
     mappers = importlib.import_module("federation.entities.%s.mappers" % found_protocol.PROTOCOL_NAME)
-    entities = mappers.message_to_objects(message, sender_key_fetcher)
+    entities = mappers.message_to_objects(message, sender_key_fetcher, user)
     logger.debug("handle_receive: entities %s", entities)
 
     return sender, found_protocol.PROTOCOL_NAME, entities

--- a/federation/tests/entities/diaspora/test_mappers.py
+++ b/federation/tests/entities/diaspora/test_mappers.py
@@ -156,13 +156,14 @@ class TestDiasporaEntityMappersReceive():
         assert entity.entity_type == "Post"
 
     def test_message_to_objects_retraction_legacy_request(self):
-        entities = message_to_objects(DIASPORA_LEGACY_REQUEST_RETRACTION)
+        entities = message_to_objects(DIASPORA_LEGACY_REQUEST_RETRACTION, user=Mock(guid="swfeuihiwehuifhiwheiuf"))
         assert len(entities) == 1
         entity = entities[0]
         assert isinstance(entity, Retraction)
         assert entity.handle == "jaywink@iliketoast.net"
         assert entity.target_guid == "7ed1555bc6ae03db"
         assert entity.entity_type == "Profile"
+        assert entity._receiving_guid == "swfeuihiwehuifhiwheiuf"
 
     def test_message_to_objects_contact(self):
         entities = message_to_objects(DIASPORA_CONTACT)


### PR DESCRIPTION
Required for example to actually use (legacy) relationship retraction.