### PR TITLE
Refactor handle_send and handle_create_payload signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [unreleased]
+
+### Changed
+* **Breaking change.** The high level `federation.outbound` functions `handle_send` and `handle_create_payload` signatures have been changed. This has been done to better represent the objects that are actually sent in and to add an optional `parent_user` object.
+
+  For both functions the `from_user` parameter has been renamed to `author_user`. Optionally a `parent_user` object can also be passed in. Both the user objects must have `private_key` and `handle` attributes. In the case that `parent_user` is given, that user will be used to sign the payload and for Diaspora relayables an extra `parent_author_signature` in the payload itself.
+
 ## [0.13.0] - 2017-07-22
 
 ### Backwards incompatible changes

--- a/federation/entities/diaspora/entities.py
+++ b/federation/entities/diaspora/entities.py
@@ -54,7 +54,10 @@ class DiasporaRelayableMixin(DiasporaEntityMixin):
         self.signature = create_relayable_signature(private_key, self.to_xml())
 
     def sign_with_parent(self, private_key):
-        doc = etree.fromstring(self._source_object)
+        if self._source_object:
+            doc = etree.fromstring(self._source_object)
+        else:
+            doc = self.to_xml()
         self.parent_signature = create_relayable_signature(private_key, doc)
         add_element_to_doc(doc, "parent_author_signature", self.parent_signature)
         self.outbound_doc = doc

--- a/federation/outbound.py
+++ b/federation/outbound.py
@@ -4,48 +4,54 @@ from federation.utils.diaspora import get_public_endpoint
 from federation.utils.network import send_document
 
 
-def handle_create_payload(entity, from_user, to_user=None):
+def handle_create_payload(entity, author_user, to_user=None, parent_user=None):
     """Create a payload with the correct protocol.
 
-    Since we don't know the protocol, we need to first query the recipient. However, for a PoC implementation,
-    supporting only Diaspora, we're going to assume that for now.
+    Any given user arguments must have ``private_key`` and ``handle`` attributes.
 
-    ``from_user`` must have ``private_key`` and ``handle`` attributes.
-    ``to_user`` must have ``key`` attribute.
-
-    :arg entity: Entity object to send
-    :arg from_user: Profile sending the object
+    :arg entity: Entity object to send. Can be a base entity or a protocol specific one.
+    :arg author_user: User authoring the object.
     :arg to_user: Profile entry to send to (required for non-public content)
+    :arg parent_user: (Optional) User object of the parent object, if there is one. This must be given for the
+                      Diaspora protocol if a parent object exists, so that a proper ``parent_author_signature`` can
+                      be generated. If given, the payload will be sent as this user.
     :returns: Built payload message (str)
     """
     # Just use Diaspora protocol for now
     protocol = Protocol()
-    outbound_entity = get_outbound_entity(entity, from_user.private_key)
-    data = protocol.build_send(entity=outbound_entity, from_user=from_user, to_user=to_user)
+    outbound_entity = get_outbound_entity(entity, author_user.private_key)
+    if parent_user:
+        outbound_entity.sign_with_parent(parent_user.private_key)
+    send_as_user = parent_user if parent_user else author_user
+    data = protocol.build_send(entity=outbound_entity, from_user=send_as_user, to_user=to_user)
     return data
 
 
-def handle_send(entity, from_user, recipients=None):
+def handle_send(entity, author_user, recipients=None, parent_user=None):
     """Send an entity to remote servers.
-
-    `from_user` must have `private_key` and `handle` attributes.
-
-    `recipients` should be a list of tuples, containing:
-        - recipient handle, domain or id
-        - protocol (optional, if known)
 
     Using this we will build a list of payloads per protocol, after resolving any that need to be guessed or
     looked up over the network. After that, each recipient will get the generated protocol payload delivered.
 
-    NOTE! This will not support Diaspora limited messages - `handle_create_payload` above should be directly
+    NOTE! This will not (yet) support Diaspora limited messages - `handle_create_payload` above should be directly
     called instead and payload sent with `federation.utils.network.send_document`.
+
+    Any given user arguments must have ``private_key`` and ``handle`` attributes.
+
+    :arg entity: Entity object to send. Can be a base entity or a protocol specific one.
+    :arg author_user: User authoring the object.
+    :arg recipients: A list of tuples to delivery to. Tuple contains (recipient handle or domain, protocol or None).
+                     For example ``[("foo@example.com", "diaspora"), ("bar@example.com", None)]``.
+    :arg parent_user: (Optional) User object of the parent object, if there is one. This must be given for the
+                      Diaspora protocol if a parent object exists, so that a proper ``parent_author_signature`` can
+                      be generated. If given, the payload will be sent as this user.
     """
     payloads = {"diaspora": {"payload": None, "recipients": set()}}
     # Generate payload per protocol and split recipients to protocols
     for recipient, protocol in recipients:
         # TODO currently we only support Diaspora protocol, so no need to guess, just generate the payload
         if not payloads["diaspora"]["payload"]:
-            payloads["diaspora"]["payload"] = handle_create_payload(entity, from_user)
+            payloads["diaspora"]["payload"] = handle_create_payload(entity, author_user, parent_user=parent_user)
         if "@" in recipient:
             payloads["diaspora"]["recipients"].add(recipient.split("@")[1])
         else:

--- a/federation/tests/conftest.py
+++ b/federation/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 import pytest
 
 from federation.entities.diaspora.entities import DiasporaPost
+from federation.tests.fixtures.keys import get_dummy_private_key
 
 
 @pytest.fixture(autouse=True)
@@ -24,3 +25,8 @@ def disable_network_calls(monkeypatch):
 @pytest.fixture
 def diasporapost():
     return DiasporaPost()
+
+
+@pytest.fixture
+def private_key():
+    return get_dummy_private_key()

--- a/federation/tests/entities/diaspora/test_entities.py
+++ b/federation/tests/entities/diaspora/test_entities.py
@@ -169,6 +169,13 @@ class TestDiasporaRelayableMixin:
                                                       b'hdOWOV8563dYo/5xS3zlQUt8I3AwXOzHr+57r1egMBHYyXTXsS8gFisj7mH4' \
                                                       b'TsLM+Yw==</parent_author_signature></comment>'
 
+    @patch("federation.entities.diaspora.mappers.DiasporaComment._validate_signatures")
+    def test_sign_with_parent(self, mock_validate):
+        entity = DiasporaComment()
+        with patch.object(entity, "to_xml") as mock_to_xml:
+            entity.sign_with_parent(get_dummy_private_key())
+            mock_to_xml.assert_called_once_with()
+
 
 class TestDiasporaRelayableEntityValidate():
     def test_raises_if_no_sender_key(self):

--- a/federation/tests/entities/diaspora/test_mappers.py
+++ b/federation/tests/entities/diaspora/test_mappers.py
@@ -11,7 +11,6 @@ from federation.entities.diaspora.entities import (
     DiasporaPost, DiasporaComment, DiasporaLike, DiasporaRequest,
     DiasporaProfile, DiasporaRetraction, DiasporaContact)
 from federation.entities.diaspora.mappers import message_to_objects, get_outbound_entity
-from federation.tests.fixtures.keys import get_dummy_private_key
 from federation.tests.fixtures.payloads import (
     DIASPORA_POST_SIMPLE, DIASPORA_POST_COMMENT, DIASPORA_POST_LIKE,
     DIASPORA_REQUEST, DIASPORA_PROFILE, DIASPORA_POST_INVALID, DIASPORA_RETRACTION,
@@ -216,70 +215,67 @@ class TestDiasporaEntityMappersReceive():
         mock_retrieve.assert_called_once_with("alice@alice.diaspora.example.org")
 
 
-class TestGetOutboundEntity():
-    def test_already_fine_entities_are_returned_as_is(self):
-        dummy_key = get_dummy_private_key()
+class TestGetOutboundEntity:
+    def test_already_fine_entities_are_returned_as_is(self, private_key):
         entity = DiasporaPost()
-        assert get_outbound_entity(entity, dummy_key) == entity
+        assert get_outbound_entity(entity, private_key) == entity
         entity = DiasporaLike()
-        assert get_outbound_entity(entity, dummy_key) == entity
+        assert get_outbound_entity(entity, private_key) == entity
         entity = DiasporaComment()
-        assert get_outbound_entity(entity, dummy_key) == entity
+        assert get_outbound_entity(entity, private_key) == entity
         entity = DiasporaRequest()
-        assert get_outbound_entity(entity, dummy_key) == entity
+        assert get_outbound_entity(entity, private_key) == entity
         entity = DiasporaProfile()
-        assert get_outbound_entity(entity, dummy_key) == entity
+        assert get_outbound_entity(entity, private_key) == entity
         entity = DiasporaContact()
-        assert get_outbound_entity(entity, dummy_key) == entity
+        assert get_outbound_entity(entity, private_key) == entity
 
-    def test_post_is_converted_to_diasporapost(self):
+    def test_post_is_converted_to_diasporapost(self, private_key):
         entity = Post()
-        assert isinstance(get_outbound_entity(entity, get_dummy_private_key()), DiasporaPost)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaPost)
 
-    def test_comment_is_converted_to_diasporacomment(self):
+    def test_comment_is_converted_to_diasporacomment(self, private_key):
         entity = Comment()
-        assert isinstance(get_outbound_entity(entity, get_dummy_private_key()), DiasporaComment)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaComment)
 
-    def test_reaction_of_like_is_converted_to_diasporalike(self):
+    def test_reaction_of_like_is_converted_to_diasporalike(self, private_key):
         entity = Reaction(reaction="like")
-        assert isinstance(get_outbound_entity(entity, get_dummy_private_key()), DiasporaLike)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaLike)
 
-    def test_relationship_of_sharing_or_following_is_converted_to_diasporarequest(self):
-        dummy_key = get_dummy_private_key()
+    def test_relationship_of_sharing_or_following_is_converted_to_diasporarequest(self, private_key):
         entity = Relationship(relationship="sharing")
-        assert isinstance(get_outbound_entity(entity, dummy_key), DiasporaRequest)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaRequest)
         entity = Relationship(relationship="following")
-        assert isinstance(get_outbound_entity(entity, dummy_key), DiasporaRequest)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaRequest)
 
-    def test_profile_is_converted_to_diasporaprofile(self):
+    def test_profile_is_converted_to_diasporaprofile(self, private_key):
         entity = Profile()
-        assert isinstance(get_outbound_entity(entity, get_dummy_private_key()), DiasporaProfile)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaProfile)
 
-    def test_other_reaction_raises(self):
+    def test_other_reaction_raises(self, private_key):
         entity = Reaction(reaction="foo")
         with pytest.raises(ValueError):
-            get_outbound_entity(entity, get_dummy_private_key())
+            get_outbound_entity(entity, private_key)
 
-    def test_other_relation_raises(self):
+    def test_other_relation_raises(self, private_key):
         entity = Relationship(relationship="foo")
         with pytest.raises(ValueError):
-            get_outbound_entity(entity, get_dummy_private_key())
+            get_outbound_entity(entity, private_key)
 
-    def test_retraction_is_converted_to_diasporaretraction(self):
+    def test_retraction_is_converted_to_diasporaretraction(self, private_key):
         entity = Retraction()
-        assert isinstance(get_outbound_entity(entity, get_dummy_private_key()), DiasporaRetraction)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaRetraction)
 
-    def test_follow_is_converted_to_diasporacontact(self):
+    def test_follow_is_converted_to_diasporacontact(self, private_key):
         entity = Follow()
-        assert isinstance(get_outbound_entity(entity, get_dummy_private_key()), DiasporaContact)
+        assert isinstance(get_outbound_entity(entity, private_key), DiasporaContact)
 
-    def test_signs_relayable_if_no_signature(self):
+    def test_signs_relayable_if_no_signature(self, private_key):
         entity = DiasporaComment()
-        dummy_key = get_dummy_private_key()
-        outbound = get_outbound_entity(entity, dummy_key)
+        outbound = get_outbound_entity(entity, private_key)
         assert outbound.signature != ""
 
-    def test_returns_entity_if_outbound_doc_on_entity(self):
+    def test_returns_entity_if_outbound_doc_on_entity(self, private_key):
         entity = Comment()
         entity.outbound_doc = "foobar"
-        assert get_outbound_entity(entity, "private_key") == entity
+        assert get_outbound_entity(entity, private_key) == entity

--- a/federation/tests/test_outbound.py
+++ b/federation/tests/test_outbound.py
@@ -2,37 +2,59 @@ from unittest.mock import Mock, patch, call
 
 from Crypto.PublicKey import RSA
 
-from federation.entities.diaspora.entities import DiasporaPost
+from federation.entities.diaspora.entities import DiasporaPost, DiasporaComment
 from federation.outbound import handle_create_payload, handle_send
 
 
-class TestHandleCreatePayloadBuildsAPayload():
+class TestHandleCreatePayloadBuildsAPayload:
     @patch("federation.outbound.Protocol")
     def test_handle_create_payload_builds_an_xml(self, mock_protocol_class):
         mock_protocol = Mock()
         mock_protocol_class.return_value = mock_protocol
-        from_user = Mock()
+        author_user = Mock()
         entity = DiasporaPost()
-        handle_create_payload(entity, from_user)
-        mock_protocol.build_send.assert_called_once_with(entity=entity, from_user=from_user, to_user=None)
+        handle_create_payload(entity, author_user)
+        mock_protocol.build_send.assert_called_once_with(entity=entity, from_user=author_user, to_user=None)
 
     @patch("federation.outbound.get_outbound_entity")
     def test_handle_create_payload_calls_get_outbound_entity(self, mock_get_outbound_entity):
         mock_get_outbound_entity.return_value = DiasporaPost()
-        from_user = Mock(private_key=RSA.generate(2048), handle="foobar@domain.tld")
+        author_user = Mock(private_key=RSA.generate(2048), handle="foobar@domain.tld")
         entity = DiasporaPost()
-        handle_create_payload(entity, from_user)
-        assert mock_get_outbound_entity.called
+        handle_create_payload(entity, author_user)
+        mock_get_outbound_entity.assert_called_once_with(entity, author_user.private_key)
+
+    @patch("federation.outbound.get_outbound_entity")
+    def test_handle_create_payload_calls_get_outbound_entity_with_author_user(self, mock_get_outbound_entity):
+        mock_get_outbound_entity.return_value = DiasporaPost()
+        author_user = Mock(private_key=RSA.generate(2048), handle="foobar@domain.tld")
+        entity = DiasporaPost()
+        handle_create_payload(entity, author_user)
+        mock_get_outbound_entity.assert_called_once_with(entity, author_user.private_key)
+
+    @patch("federation.outbound.get_outbound_entity")
+    def test_handle_create_payload_calls_sign_with_parent(self, mock_get_outbound_entity):
+        comment = DiasporaComment()
+        mock_get_outbound_entity.return_value = comment
+        author_user = Mock(private_key=RSA.generate(2048), handle="foobar@domain.tld")
+        parent_user = Mock(private_key=RSA.generate(2048), handle="parent@domain.tld")
+        entity = DiasporaComment()
+        with patch.object(comment, "sign_with_parent") as mock_sign:
+            handle_create_payload(entity, author_user, parent_user=parent_user)
+            mock_sign.assert_called_once_with(parent_user.private_key)
 
 
 @patch("federation.outbound.handle_create_payload", return_value="payload")
 @patch("federation.outbound.send_document")
-class TestHandleSend():
+class TestHandleSend:
     def test_calls_handle_create_payload(self, mock_send, mock_create, diasporapost):
         recipients = [("foo@127.0.0.1", "diaspora"), ("localhost", None)]
-        mock_from_user = Mock()
-        handle_send(diasporapost, mock_from_user, recipients)
-        mock_create.assert_called_once_with(diasporapost, mock_from_user)
+        mock_author = Mock()
+        handle_send(diasporapost, mock_author, recipients)
+        mock_create.assert_called_once_with(diasporapost, mock_author, parent_user=None)
+        mock_create.reset_mock()
+        handle_send(diasporapost, mock_author, recipients, parent_user="parent_user")
+        mock_create.assert_called_once_with(diasporapost, mock_author, parent_user="parent_user")
 
     def test_calls_send_document(self, mock_send, mock_create, diasporapost):
         recipients = [("foo@127.0.0.1", "diaspora"), ("localhost", None)]


### PR DESCRIPTION
**Breaking change.** The high level `federation.outbound` functions `handle_send` and `handle_create_payload` signatures have been changed. This has been done to better represent the objects that are actually sent in and to add an optional `parent_user` object.

For both functions the `from_user` parameter has been renamed to `author_user`. Optionally a `parent_user` object can also be passed in. Both the user objects must have `private_key` and `handle` attributes. In the case that `parent_user` is given, that user will be used to sign the payload and for Diaspora relayables an extra `parent_author_signature` in the payload itself.