### PR TITLE
Verify payload and entity handle are the same

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+### Security
+* Add proper checks to make sure Diaspora protocol payload handle and entity handle are the same. Even though we already verified the signature of the sender, we didn't ensure that the sender isn't trying to fake an entity authored by someone else. 
+
+  The Diaspora protocol functions `message_to_objects` and `element_to_objects` now require a new parameter, the payload sender handle. These functions should normally not be needed to be used directly. 
+
 ### Changed
 * **Breaking change.** The high level `federation.outbound` functions `handle_send` and `handle_create_payload` signatures have been changed. This has been done to better represent the objects that are actually sent in and to add an optional `parent_user` object.
 

--- a/federation/inbound.py
+++ b/federation/inbound.py
@@ -48,7 +48,7 @@ def handle_receive(payload, user=None, sender_key_fetcher=None, skip_author_veri
         raise NoSuitableProtocolFoundError()
 
     mappers = importlib.import_module("federation.entities.%s.mappers" % found_protocol.PROTOCOL_NAME)
-    entities = mappers.message_to_objects(message, sender_key_fetcher, user)
+    entities = mappers.message_to_objects(message, sender, sender_key_fetcher, user)
     logger.debug("handle_receive: entities %s", entities)
 
     return sender, found_protocol.PROTOCOL_NAME, entities

--- a/federation/tests/entities/diaspora/test_entities.py
+++ b/federation/tests/entities/diaspora/test_entities.py
@@ -147,7 +147,8 @@ class TestDiasporaRelayableMixin:
 
     @patch("federation.entities.diaspora.mappers.DiasporaComment._validate_signatures")
     def test_sign_with_parent(self, mock_validate):
-        entities = message_to_objects(DIASPORA_POST_COMMENT, sender_key_fetcher=Mock())
+        entities = message_to_objects(DIASPORA_POST_COMMENT, "alice@alice.diaspora.example.org",
+                                      sender_key_fetcher=Mock())
         entity = entities[0]
         entity.sign_with_parent(get_dummy_private_key())
         assert entity.parent_signature == "UTIDiFZqjxfU6ssVlmjz2RwOD/WPmMTFv57qOm0BZvBhF8Ef49Ynse1c2XTtx3rs8DyRMn54" \

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -118,7 +118,7 @@ DIASPORA_POST_WITH_PHOTOS_2 = """
         <raw_message>#foo #bar (fewfefewfwfewfwe)</raw_message>
         <photo>
             <guid>fjwjewiofjoiwjfiowefewew</guid>
-            <diaspora_handle>xxxxxxxxxxxxxxxxx@diasp.org</diaspora_handle>
+            <diaspora_handle>xxxxxxxxxxxxxxx@diasp.org</diaspora_handle>
             <public>true</public>
             <created_at>2017-06-10T14:41:28Z</created_at>
             <remote_photo_path>https://diasp.org/uploads/images/</remote_photo_path>


### PR DESCRIPTION
Add proper checks to make sure Diaspora protocol payload handle and entity handle are the same. Even though we already verified the signature of the sender, we didn't ensure that the sender isn't trying to fake an entity authored by someone else.

The Diaspora protocol functions `message_to_objects` and `element_to_objects` now require a new parameter, the payload sender handle. These functions should normally not be needed to be used directly.