### PR TITLE
Fix regression in handling Diaspora relayables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [unreleased]
+
+### Fixed
+* Fix regression in handling Diaspora relayables due to security fix in 0.14.0. Payload and entity handle need to be allowed to be different when handling relayables.
+
 ## [0.14.0] - 2017-08-06
 
 ### Security


### PR DESCRIPTION
Due to security fix in 0.14.0. Payload and entity handle need to be allowed to be different when handling relayables.