### PR TITLE
Fix DiasporaProfile.from_base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [unreleased]
+
+### Fixed
+* Converting base entity `Profile` to `DiasporaProfile` for outbound sending missed two attributes, `image_urls` and `tag_list`. Those are now included so that the values transfer into the built payload.
+
 ## [0.14.1] - 2017-08-06
 
 ### Fixed

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -294,6 +294,8 @@ class Profile(CreatedAtMixin, HandleMixin, OptionalRawContentMixin, PublicMixin,
     location = ""
     nsfw = False
     public_key = ""
+    image_urls = None
+    tag_list = None
 
     _allowed_children = (Image,)
 

--- a/federation/tests/entities/diaspora/test_utils.py
+++ b/federation/tests/entities/diaspora/test_utils.py
@@ -4,7 +4,7 @@ import re
 import arrow
 from lxml import etree
 
-from federation.entities.base import Post
+from federation.entities.base import Post, Profile
 from federation.entities.diaspora.utils import (
     get_base_attributes, get_full_xml_representation, format_dt, add_element_to_doc)
 
@@ -17,7 +17,12 @@ class TestGetBaseAttributes:
             "created_at", "guid", "handle", "location", "provider_display_name", "public", "raw_content",
             "signature",
         }
-
+        entity = Profile()
+        attrs = get_base_attributes(entity).keys()
+        assert set(attrs) == {
+            "created_at", "guid", "handle", "name", "email", "gender", "raw_content", "location", "public",
+            "nsfw", "public_key", "image_urls", "tag_list", "signature",
+        }
 
 class TestGetFullXMLRepresentation:
     def test_returns_xml_document(self):


### PR DESCRIPTION
Converting base entity `Profile` to `DiasporaProfile` for outbound sending missed two attributes, `image_urls` and `tag_list`. Those are now included so that the values transfer into the built payload.