### PR TITLE
Added base entity Share

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [unreleased]
 
+### Added
+* Added base entity `Share` which maps to a `DiasporaReshare` for the Diaspora protocol. ([related issue](https://github.com/jaywink/federation/issues/94))
+
+  The `Share` entity supports all the properties that a Diaspora reshare does. Additionally two other properties are supported: `raw_content` and `entity_type`. The former can be used for a "quoted share" case where the sharer adds their own note to the share. The latter can be used to reference the type of object that was shared, to help the receiver, if it is not sharing a `Post` entity. The value must be a base entity class name.
+
 ### Fixed
 * Converting base entity `Profile` to `DiasporaProfile` for outbound sending missed two attributes, `image_urls` and `tag_list`. Those are now included so that the values transfer into the built payload.
 

--- a/docs/protocols.rst
+++ b/docs/protocols.rst
@@ -24,6 +24,7 @@ The feature set supported by this release is approximately the following:
    * Retraction
    * StatusMessage
    * Contact
+   * Reshare
 
 Implementation unfortunately currently requires knowledge of how Diaspora discovery works as the implementer has to implement all the necessary views correctly (even though this library provides document generators). However, the magic envelope, signature and entity building is all abstracted inside the library.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -17,6 +17,7 @@ Entity types are as follows below.
 .. autoclass:: federation.entities.base.Reaction
 .. autoclass:: federation.entities.base.Relationship
 .. autoclass:: federation.entities.base.Retraction
+.. autoclass:: federation.entities.base.Share
 
 Protocol entities
 .................

--- a/federation/entities/diaspora/entities.py
+++ b/federation/entities/diaspora/entities.py
@@ -1,6 +1,7 @@
 from lxml import etree
 
-from federation.entities.base import Comment, Post, Reaction, Relationship, Profile, Retraction, BaseEntity, Follow
+from federation.entities.base import (
+    Comment, Post, Reaction, Relationship, Profile, Retraction, BaseEntity, Follow, Share)
 from federation.entities.diaspora.utils import format_dt, struct_to_xml, get_base_attributes, add_element_to_doc
 from federation.exceptions import SignatureVerificationError
 from federation.protocols.diaspora.signatures import verify_relayable_signature, create_relayable_signature
@@ -211,3 +212,22 @@ class DiasporaRetraction(DiasporaEntityMixin, Retraction):
             index = values.index(value)
             return list(DiasporaRetraction.mapped.keys())[index]
         return value
+
+
+class DiasporaReshare(DiasporaEntityMixin, Share):
+    """Diaspora Reshare."""
+    def to_xml(self):
+        element = etree.Element("reshare")
+        struct_to_xml(element, [
+            {"author": self.handle},
+            {"guid": self.guid},
+            {"created_at": format_dt(self.created_at)},
+            {"root_author": self.target_handle},
+            {"root_guid": self.target_guid},
+            {"provider_display_name": self.provider_display_name},
+            {"public": "true" if self.public else "false"},
+            # Some of our own not in Diaspora protocol
+            {"raw_content": self.raw_content},
+            {"entity_type": self.entity_type},
+        ])
+        return element

--- a/federation/tests/entities/test_base.py
+++ b/federation/tests/entities/test_base.py
@@ -4,11 +4,11 @@ import pytest
 
 from federation.entities.base import (
     BaseEntity, Relationship, Profile, RawContentMixin, GUIDMixin, HandleMixin, PublicMixin, Image, Retraction,
-    Follow)
-from federation.tests.factories.entities import TaggedPostFactory, PostFactory
+    Follow, TargetHandleMixin)
+from federation.tests.factories.entities import TaggedPostFactory, PostFactory, ShareFactory
 
 
-class TestPostEntityTags():
+class TestPostEntityTags:
     def test_post_entity_returns_list_of_tags(self):
         post = TaggedPostFactory()
         assert post.tags == {"tagone", "tagtwo", "tagthree", "upper", "snakecase"}
@@ -18,7 +18,7 @@ class TestPostEntityTags():
         assert post.tags == set()
 
 
-class TestBaseEntityCallsValidateMethods():
+class TestBaseEntityCallsValidateMethods:
     def test_entity_calls_attribute_validate_method(self):
         post = PostFactory()
         post.validate_location = Mock()
@@ -48,28 +48,41 @@ class TestBaseEntityCallsValidateMethods():
             post._validate_children()
 
 
-class TestGUIDMixinValidate():
+class TestGUIDMixinValidate:
     def test_validate_guid_raises_on_low_length(self):
         guid = GUIDMixin(guid="x"*15)
         with pytest.raises(ValueError):
             guid.validate()
+        guid = GUIDMixin(guid="x" * 16)
+        guid.validate()
 
 
-class TestHandleMixinValidate():
+class TestHandleMixinValidate:
     def test_validate_handle_raises_on_invalid_format(self):
         handle = HandleMixin(handle="foobar")
         with pytest.raises(ValueError):
             handle.validate()
+        handle = HandleMixin(handle="foobar@example.com")
+        handle.validate()
 
 
-class TestPublicMixinValidate():
+class TestTargetHandleMixinValidate:
+    def test_validate_target_handle_raises_on_invalid_format(self):
+        handle = TargetHandleMixin(target_handle="foobar")
+        with pytest.raises(ValueError):
+            handle.validate()
+        handle = TargetHandleMixin(target_handle="foobar@example.com")
+        handle.validate()
+
+
+class TestPublicMixinValidate:
     def test_validate_public_raises_on_low_length(self):
         public = PublicMixin(public="foobar")
         with pytest.raises(ValueError):
             public.validate()
 
 
-class TestEntityRequiredAttributes():
+class TestEntityRequiredAttributes:
     def test_entity_checks_for_required_attributes(self):
         entity = BaseEntity()
         entity._required = ["foobar"]
@@ -85,7 +98,7 @@ class TestEntityRequiredAttributes():
             entity.validate()
 
 
-class TestRelationshipEntity():
+class TestRelationshipEntity:
     def test_instance_creation(self):
         entity = Relationship(handle="bob@example.com", target_handle="alice@example.com", relationship="following")
         assert entity
@@ -95,13 +108,8 @@ class TestRelationshipEntity():
             entity = Relationship(handle="bob@example.com", target_handle="alice@example.com", relationship="hating")
             entity.validate()
 
-    def test_instance_creation_validates_target_handle_value(self):
-        with pytest.raises(ValueError):
-            entity = Relationship(handle="bob@example.com", target_handle="fefle.com", relationship="following")
-            entity.validate()
 
-
-class TestProfileEntity():
+class TestProfileEntity:
     def test_instance_creation(self):
         entity = Profile(handle="bob@example.com", raw_content="foobar")
         assert entity
@@ -117,7 +125,7 @@ class TestProfileEntity():
             entity.validate()
 
 
-class TestImageEntity():
+class TestImageEntity:
     def test_instance_creation(self):
         entity = Image(
             guid="x"*16, handle="foo@example.com", public=False, remote_path="foobar", remote_name="barfoo"
@@ -137,7 +145,7 @@ class TestImageEntity():
             entity.validate()
 
 
-class TestRetractionEntity():
+class TestRetractionEntity:
     def test_instance_creation(self):
         entity = Retraction(
             handle="foo@example.com", target_guid="x"*16, entity_type="Post"
@@ -162,16 +170,15 @@ class TestRetractionEntity():
             entity.validate()
 
 
-class TestFollowEntity():
+class TestFollowEntity:
     def test_instance_creation(self):
         entity = Follow(
             handle="foo@example.com", target_handle="bar@example.org", following=True
         )
         entity.validate()
 
-    def test_required_validates(self):
-        entity = Follow(
-            handle="foo@example.com", following=True
-        )
-        with pytest.raises(ValueError):
-            entity.validate()
+
+class TestShareEntity:
+    def test_instance_creation(self):
+        entity = ShareFactory()
+        entity.validate()

--- a/federation/tests/factories/entities.py
+++ b/federation/tests/factories/entities.py
@@ -1,9 +1,8 @@
-# -*- coding: utf-8 -*-
 from random import shuffle
 import factory
 from factory import fuzzy
 
-from federation.entities.base import Post, Profile
+from federation.entities.base import Post, Profile, Share
 from federation.entities.diaspora.entities import DiasporaPost
 
 
@@ -47,3 +46,15 @@ class ProfileFactory(GUIDMixinFactory, HandleMixinFactory, RawContentMixinFactor
 
     name = fuzzy.FuzzyText(length=30)
     public_key = fuzzy.FuzzyText(length=300)
+
+
+class ShareFactory(GUIDMixinFactory, HandleMixinFactory):
+    class Meta:
+        model = Share
+
+    target_guid = factory.Faker("uuid4")
+    entity_type = "Post"
+    raw_content = ""
+    public = factory.Faker("pybool")
+    provider_display_name = ""
+    target_handle = factory.Faker("safe_email")

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -231,3 +231,41 @@ DIASPORA_CONTACT = """
         <sharing>true</sharing>
     </contact>
 """
+
+DIASPORA_RESHARE = """
+    <reshare>
+        <author>alice@example.org</author>
+        <guid>a0b53e5029f6013487753131731751e9</guid>
+        <created_at>2016-07-12T00:36:42Z</created_at>
+        <provider_display_name/>
+        <root_author>bob@example.com</root_author>
+        <root_guid>a0b53bc029f6013487753131731751e9</root_guid>
+        <public>true</public>
+    </reshare>
+"""
+
+DIASPORA_RESHARE_LEGACY = """
+    <reshare>
+        <diaspora_handle>alice@example.org</diaspora_handle>
+        <guid>a0b53e5029f6013487753131731751e9</guid>
+        <created_at>2016-07-12T00:36:42Z</created_at>
+        <provider_display_name/>
+        <root_diaspora_id>bob@example.com</root_diaspora_id>
+        <root_guid>a0b53bc029f6013487753131731751e9</root_guid>
+        <public>true</public>
+    </reshare>
+"""
+
+DIASPORA_RESHARE_WITH_EXTRA_PROPERTIES = """
+    <reshare>
+        <author>alice@example.org</author>
+        <guid>a0b53e5029f6013487753131731751e9</guid>
+        <created_at>2016-07-12T00:36:42Z</created_at>
+        <provider_display_name/>
+        <root_author>bob@example.com</root_author>
+        <root_guid>a0b53bc029f6013487753131731751e9</root_guid>
+        <public>true</public>
+        <raw_content>Important note here</raw_content>
+        <entity_type>Comment</entity_type>
+    </reshare>
+"""


### PR DESCRIPTION
Maps to a `DiasporaReshare` for the Diaspora protocol.

The `Share` entity supports all the properties that a Diaspora reshare does. Additionally two other properties are supported: `raw_content` and `entity_type`. The former can be used for a "quoted share" case where the sharer adds their own note to the share. The latter can be used to reference the type of object that was shared, to help the receiver, if it is not sharing a `Post` entity. The value must be a base entity class name.

TODO:
* [x] Support legacy diaspora reshare too

Closes #94