### PR TITLE
New high level fetcher function retrieve_remote_content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@
 * Added base entity `Share` which maps to a `DiasporaReshare` for the Diaspora protocol. ([related issue](https://github.com/jaywink/federation/issues/94))
 
   The `Share` entity supports all the properties that a Diaspora reshare does. Additionally two other properties are supported: `raw_content` and `entity_type`. The former can be used for a "quoted share" case where the sharer adds their own note to the share. The latter can be used to reference the type of object that was shared, to help the receiver, if it is not sharing a `Post` entity. The value must be a base entity class name.
+  
+* New high level fetcher function `federation.fetchers.retrieve_remote_content`. ([related issue](https://github.com/jaywink/federation/issues/103))
+
+  This function takes the following parameters:
+  
+    * `entity_class` - Base entity class to fetch (for example `Post`).
+    * `id` - Object ID. Currently since only Diaspora is supported and the ID is expected to be in format `<guid>@<domain.tld>`.
+    * `sender_key_fetcher` - Optional function that takes a profile `handle` and returns a public key in `str` format. If this is not given, the public key will be fetched from the remote profile over the network.
+    
+  The given ID will be fetched using the correct entity class specific remote endpoint, validated to be from the correct author against their public key and then an instance of the entity class will be constructed and returned.
+
+* New Diaspora protocol helper `federation.utils.diaspora.retrieve_and_parse_content`. See notes regarding the high level fetcher above.
+
+* New Diaspora protocol helper `federation.utils.fetch_public_key`. Given a `handle` as a parameter, will fetch the remote profile and return the `public_key` from it.
+
+### Changed
+* Refactoring for Diaspora `MagicEnvelope` class.
+
+  The class init now also allows passing in parameters to construct and verify MagicEnvelope instances. The order of init parameters has not been changed, but they are now all optional. When creating a class instance, one should always pass in the necessary parameters depnding on whether the class instance will be used for building a payload or verifying an incoming payload. See class docstring for details.
+  
+* Diaspora procotol receive flow now uses the `MagicEnvelope` class to verify payloads.
+
+* Diaspora protocol receive flow now fetches the sender public key over the network if a `sender_key_fetcher` function is not passed in. Previously an error would be raised.
+
+  Note that fetching over the network for each payload is wasteful. Implementers should instead cache public keys when possible and pass in a function to retrieve them, as before.
 
 ### Fixed
 * Converting base entity `Profile` to `DiasporaProfile` for outbound sending missed two attributes, `image_urls` and `tag_list`. Those are now included so that the values transfer into the built payload.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,27 +6,32 @@
 * Added base entity `Share` which maps to a `DiasporaReshare` for the Diaspora protocol. ([related issue](https://github.com/jaywink/federation/issues/94))
 
   The `Share` entity supports all the properties that a Diaspora reshare does. Additionally two other properties are supported: `raw_content` and `entity_type`. The former can be used for a "quoted share" case where the sharer adds their own note to the share. The latter can be used to reference the type of object that was shared, to help the receiver, if it is not sharing a `Post` entity. The value must be a base entity class name.
-  
+ 
+* Entities have two new properties: `id` and `target_id`.
+
+  Diaspora entity ID's are in the form of the [Diaspora URI scheme](https://diaspora.github.io/diaspora_federation/federation/diaspora_scheme.html), where it is possible to construct an ID from the entity. In the future, ActivityPub object ID's will be found in these properties. 
+
 * New high level fetcher function `federation.fetchers.retrieve_remote_content`. ([related issue](https://github.com/jaywink/federation/issues/103))
 
   This function takes the following parameters:
   
-    * `entity_class` - Base entity class to fetch (for example `Post`).
-    * `id` - Object ID. Currently since only Diaspora is supported and the ID is expected to be in format `<guid>@<domain.tld>`.
+    * `id` - Object ID. For Diaspora, the only supported protocol at the moment, this is in the [Diaspora URI](https://diaspora.github.io/diaspora_federation/federation/diaspora_scheme.html) format.
     * `sender_key_fetcher` - Optional function that takes a profile `handle` and returns a public key in `str` format. If this is not given, the public key will be fetched from the remote profile over the network.
     
-  The given ID will be fetched using the correct entity class specific remote endpoint, validated to be from the correct author against their public key and then an instance of the entity class will be constructed and returned.
+  The given ID will be fetched from the remote endpoint, validated to be from the correct author against their public key and then an instance of the entity class will be constructed and returned.
 
-* New Diaspora protocol helper `federation.utils.diaspora.retrieve_and_parse_content`. See notes regarding the high level fetcher above.
+* New Diaspora protocol helpers in `federation.utils.diaspora`:
 
-* New Diaspora protocol helper `federation.utils.fetch_public_key`. Given a `handle` as a parameter, will fetch the remote profile and return the `public_key` from it.
+  * `retrieve_and_parse_content`. See notes regarding the high level fetcher above.
+  * `fetch_public_key`. Given a `handle` as a parameter, will fetch the remote profile and return the `public_key` from it.
+  * `parse_diaspora_uri`. Parses a Diaspora URI scheme string, returns either `None` if parsing fails or a `tuple` of `handle`, `entity_type` and `guid`. 
 
 ### Changed
 * Refactoring for Diaspora `MagicEnvelope` class.
 
   The class init now also allows passing in parameters to construct and verify MagicEnvelope instances. The order of init parameters has not been changed, but they are now all optional. When creating a class instance, one should always pass in the necessary parameters depnding on whether the class instance will be used for building a payload or verifying an incoming payload. See class docstring for details.
   
-* Diaspora procotol receive flow now uses the `MagicEnvelope` class to verify payloads.
+* Diaspora procotol receive flow now uses the `MagicEnvelope` class to verify payloads. No functional changes regarding verification otherwise.
 
 * Diaspora protocol receive flow now fetches the sender public key over the network if a `sender_key_fetcher` function is not passed in. Previously an error would be raised.
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -66,6 +66,7 @@ Fetchers
 
 High level utility functions to fetch remote objects. These should be favoured instead of protocol specific utility functions.
 
+.. autofunction:: federation.fetchers.retrieve_remote_content
 .. autofunction:: federation.fetchers.retrieve_remote_profile
 
 
@@ -105,7 +106,11 @@ Various utils are provided for internal and external usage.
 Diaspora
 ........
 
+.. autofunction:: federation.utils.diaspora.fetch_public_key
+.. autofunction:: federation.utils.diaspora.get_fetch_content_endpoint
+.. autofunction:: federation.utils.diaspora.get_public_endpoint
 .. autofunction:: federation.utils.diaspora.parse_profile_from_hcard
+.. autofunction:: federation.utils.diaspora.retrieve_and_parse_content
 .. autofunction:: federation.utils.diaspora.retrieve_and_parse_profile
 .. autofunction:: federation.utils.diaspora.retrieve_diaspora_hcard
 .. autofunction:: federation.utils.diaspora.retrieve_diaspora_webfinger

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -109,6 +109,7 @@ Diaspora
 .. autofunction:: federation.utils.diaspora.fetch_public_key
 .. autofunction:: federation.utils.diaspora.get_fetch_content_endpoint
 .. autofunction:: federation.utils.diaspora.get_public_endpoint
+.. autofunction:: federation.utils.diaspora.parse_diaspora_uri
 .. autofunction:: federation.utils.diaspora.parse_profile_from_hcard
 .. autofunction:: federation.utils.diaspora.retrieve_and_parse_content
 .. autofunction:: federation.utils.diaspora.retrieve_and_parse_profile

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -30,6 +30,14 @@ class BaseEntity:
                     self.__class__.__name__, key
                 ))
 
+    @property
+    def id(self):
+        """Global network ID.
+
+        Future expansion: Convert later into an attribute which with ActivityPub will have the 'id' directly.
+        """
+        return
+
     def validate(self):
         """Do validation.
 
@@ -119,6 +127,14 @@ class TargetGUIDMixin(BaseEntity):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._required += ["target_guid"]
+
+    @property
+    def target_id(self):
+        """Global network target ID.
+
+        Future expansion: convert to attribute when ActivityPub is supported.
+        """
+        return
 
     def validate_target_guid(self):
         if len(self.target_guid) < 16:

--- a/federation/entities/diaspora/mappers.py
+++ b/federation/entities/diaspora/mappers.py
@@ -12,6 +12,18 @@ from federation.utils.diaspora import retrieve_and_parse_profile
 
 logger = logging.getLogger("federation")
 
+BASE_MAPPINGS = {
+    Comment: "comment",
+    Follow: "contact",
+    Image: "photo",
+    Post: "status_message",
+    Profile: "profile",
+    Reaction: "like",
+    Relationship: "request",
+    Retraction: "retraction",
+    Share: "reshare",
+}
+
 MAPPINGS = {
     "status_message": DiasporaPost,
     "photo": Image,

--- a/federation/entities/diaspora/mappers.py
+++ b/federation/entities/diaspora/mappers.py
@@ -3,26 +3,15 @@ from datetime import datetime
 
 from lxml import etree
 
-from federation.entities.base import Image, Relationship, Post, Reaction, Comment, Profile, Retraction, Follow, Share
+from federation.entities.base import Comment, Follow, Image, Post, Profile, Reaction, Relationship, Retraction, Share
 from federation.entities.diaspora.entities import (
-    DiasporaPost, DiasporaComment, DiasporaLike, DiasporaRequest, DiasporaProfile, DiasporaRetraction,
-    DiasporaRelayableMixin, DiasporaContact, DiasporaReshare)
+    DiasporaComment, DiasporaContact, DiasporaLike, DiasporaPost,
+    DiasporaProfile, DiasporaRelayableMixin, DiasporaRequest, DiasporaReshare, DiasporaRetraction,
+)
 from federation.protocols.diaspora.signatures import get_element_child_info
 from federation.utils.diaspora import retrieve_and_parse_profile
 
 logger = logging.getLogger("federation")
-
-BASE_MAPPINGS = {
-    Comment: "comment",
-    Follow: "contact",
-    Image: "photo",
-    Post: "status_message",
-    Profile: "profile",
-    Reaction: "like",
-    Relationship: "request",
-    Retraction: "retraction",
-    Share: "reshare",
-}
 
 MAPPINGS = {
     "status_message": DiasporaPost,

--- a/federation/fetchers.py
+++ b/federation/fetchers.py
@@ -1,20 +1,19 @@
 import importlib
 
 
-def retrieve_remote_content(entity_class, id, sender_key_fetcher=None):
+def retrieve_remote_content(id, sender_key_fetcher=None):
     """Retrieve remote content and return an Entity object.
 
     Currently, due to no other protocols supported, always use the Diaspora protocol.
 
-    :param entity_class: Federation entity class (from ``federation.entity.base``).
-    :param id: ID of the remote entity, in format``guid@domain.tld``.
+    :param id: ID of the remote entity.
     :param sender_key_fetcher: Function to use to fetch sender public key. If not given, network will be used
         to fetch the profile and the key. Function must take handle as only parameter and return a public key.
     :returns: Entity class instance or ``None``
     """
     protocol_name = "diaspora"
     utils = importlib.import_module("federation.utils.%s" % protocol_name)
-    return utils.retrieve_and_parse_content(entity_class, id, sender_key_fetcher=sender_key_fetcher)
+    return utils.retrieve_and_parse_content(id, sender_key_fetcher=sender_key_fetcher)
 
 
 def retrieve_remote_profile(handle):

--- a/federation/fetchers.py
+++ b/federation/fetchers.py
@@ -1,5 +1,20 @@
-# -*- coding: utf-8 -*-
 import importlib
+
+
+def retrieve_remote_content(entity_class, id, sender_key_fetcher=None):
+    """Retrieve remote content and return an Entity object.
+
+    Currently, due to no other protocols supported, always use the Diaspora protocol.
+
+    :param entity_class: Federation entity class (from ``federation.entity.base``).
+    :param id: ID of the remote entity, in format``guid@domain.tld``.
+    :param sender_key_fetcher: Function to use to fetch sender public key. If not given, network will be used
+        to fetch the profile and the key. Function must take handle as only parameter and return a public key.
+    :returns: Entity class instance or ``None``
+    """
+    protocol_name = "diaspora"
+    utils = importlib.import_module("federation.utils.%s" % protocol_name)
+    return utils.retrieve_and_parse_content(entity_class, id, sender_key_fetcher=sender_key_fetcher)
 
 
 def retrieve_remote_profile(handle):
@@ -10,7 +25,7 @@ def retrieve_remote_profile(handle):
 
     Currently, due to no other protocols supported, always use the Diaspora protocol.
 
-    :arg handle: The profile handle in format username@domain.tld
+    :param handle: The profile handle in format username@domain.tld
     :returns: ``federation.entities.base.Profile`` or ``None``
     """
     protocol_name = "diaspora"

--- a/federation/protocols/diaspora/magic_envelope.py
+++ b/federation/protocols/diaspora/magic_envelope.py
@@ -1,9 +1,13 @@
 from base64 import urlsafe_b64encode, b64encode, urlsafe_b64decode
 
 from Crypto.Hash import SHA256
-from Crypto.Signature import PKCS1_v1_5 as PKCSSign
+from Crypto.PublicKey import RSA
+from Crypto.Signature import PKCS1_v1_5
 from lxml import etree
 
+from federation.exceptions import SignatureVerificationError
+from federation.utils.diaspora import fetch_public_key
+from federation.utils.text import decode_if_bytes
 
 NAMESPACE = "http://salmon-protocol.org/ns/magic-env"
 
@@ -11,25 +15,70 @@ NAMESPACE = "http://salmon-protocol.org/ns/magic-env"
 class MagicEnvelope:
     """Diaspora protocol magic envelope.
 
-    See: http://diaspora.github.io/diaspora_federation/federation/magicsig.html
+    Can be used to construct and deconstruct MagicEnvelope documents.
+
+    When constructing, the following parameters should be given:
+    * message
+    * private_key
+    * author_handle
+
+    When deconstructing, the following should be given:
+    * payload
+    * public_key (optional, will be fetched if not given, using either 'sender_key_fetcher' or remote server)
+
+    Upstream specification: http://diaspora.github.io/diaspora_federation/federation/magicsig.html
     """
 
     nsmap = {
         "me": NAMESPACE,
     }
 
-    def __init__(self, message, private_key, author_handle, wrap_payload=False):
+    def __init__(self, message=None, private_key=None, author_handle=None, wrap_payload=False, payload=None,
+                 public_key=None, sender_key_fetcher=None, verify=False, doc=None):
         """
-        Args:
-            wrap_payload (bool) - Whether to wrap the message in <XML><post></post></XML>.
-                This is part of the legacy Diaspora protocol which will be removed in the future. (default False)
+        All parameters are optional. Some are required for signing, some for opening.
+
+        :param message: Message string. Required to create a MagicEnvelope document.
+        :param private_key: Private key RSA object.
+        :param author_handle: Author signing the Magic Envelope, owns the private key.
+        :param wrap_payload: - Boolean, whether to wrap the message in <XML><post></post></XML>.
+            This is part of the legacy Diaspora protocol which will be removed in the future. (default False)
+        :param payload: Magic Envelope payload as str or bytes.
+        :param public_key: Author public key in str format.
+        :param sender_key_fetcher: Function to use to fetch sender public key, if public key not given. Will fall back
+            to network fetch of the profile and the key. Function must take handle as only parameter and return
+            a public key string.
+        :param verify: Verify after creating object, defaults to False.
+        :param doc: MagicEnvelope document.
         """
-        self.message = message
+        self._message = message
         self.private_key = private_key
         self.author_handle = author_handle
         self.wrap_payload = wrap_payload
-        self.doc = None
-        self.payload = None
+        self.payload = payload
+        self.public_key = public_key
+        self.sender_key_fetcher = sender_key_fetcher
+        if payload:
+            self.extract_payload()
+        elif doc is not None:
+            self.doc = doc
+        else:
+            self.doc = None
+        if verify:
+            self.verify()
+
+    def extract_payload(self):
+        payload = decode_if_bytes(self.payload)
+        payload = payload.lstrip().encode("utf-8")
+        self.doc = etree.fromstring(payload)
+        self.author_handle = self.get_sender(self.doc)
+        self.message = self.message_from_doc()
+
+    def fetch_public_key(self):
+        if self.sender_key_fetcher:
+            self.public_key = self.sender_key_fetcher(self.author_handle)
+            return
+        self.public_key = fetch_public_key(self.author_handle)
 
     @staticmethod
     def get_sender(doc):
@@ -40,6 +89,19 @@ class MagicEnvelope:
         """
         key_id = doc.find(".//{%s}sig" % NAMESPACE).get("key_id")
         return urlsafe_b64decode(key_id).decode("utf-8")
+
+    @property
+    def message(self):
+        return self._message
+
+    @message.setter
+    def message(self, value):
+        self._message = value
+
+    def message_from_doc(self):
+        message = self.doc.find(
+            ".//{http://salmon-protocol.org/ns/magic-env}data").text
+        return urlsafe_b64decode(message.encode("ascii"))
 
     def create_payload(self):
         """Create the payload doc.
@@ -65,7 +127,7 @@ class MagicEnvelope:
             b64encode(b"base64url").decode("ascii") + "." + \
             b64encode(b"RSA-SHA256").decode("ascii")
         sig_hash = SHA256.new(sig_contents.encode("ascii"))
-        cipher = PKCSSign.new(self.private_key)
+        cipher = PKCS1_v1_5.new(self.private_key)
         sig = urlsafe_b64encode(cipher.sign(sig_hash))
         key_id = urlsafe_b64encode(bytes(self.author_handle, encoding="utf-8"))
         return sig, key_id
@@ -84,3 +146,20 @@ class MagicEnvelope:
         if self.doc is None:
             self.build()
         return etree.tostring(self.doc, encoding="unicode")
+
+    def verify(self):
+        """Verify Magic Envelope document against public key."""
+        if not self.public_key:
+            self.fetch_public_key()
+        data = self.doc.find(".//{http://salmon-protocol.org/ns/magic-env}data").text
+        sig = self.doc.find(".//{http://salmon-protocol.org/ns/magic-env}sig").text
+        sig_contents = '.'.join([
+            data,
+            b64encode(b"application/xml").decode("ascii"),
+            b64encode(b"base64url").decode("ascii"),
+            b64encode(b"RSA-SHA256").decode("ascii")
+        ])
+        sig_hash = SHA256.new(sig_contents.encode("ascii"))
+        cipher = PKCS1_v1_5.new(RSA.importKey(self.public_key))
+        if not cipher.verify(sig_hash, urlsafe_b64decode(sig)):
+            raise SignatureVerificationError("Signature cannot be verified using the given public key")

--- a/federation/tests/conftest.py
+++ b/federation/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 
 from federation.entities.diaspora.entities import DiasporaPost
 from federation.tests.fixtures.keys import get_dummy_private_key
+from federation.tests.fixtures.payloads import DIASPORA_PUBLIC_PAYLOAD
 
 
 @pytest.fixture(autouse=True)
@@ -23,6 +24,11 @@ def disable_network_calls(monkeypatch):
 
 
 @pytest.fixture
+def diaspora_public_payload():
+    return DIASPORA_PUBLIC_PAYLOAD
+
+
+@pytest.fixture
 def diasporapost():
     return DiasporaPost()
 
@@ -30,3 +36,8 @@ def diasporapost():
 @pytest.fixture
 def private_key():
     return get_dummy_private_key()
+
+
+@pytest.fixture
+def public_key(private_key):
+    return private_key.publickey().exportKey()

--- a/federation/tests/conftest.py
+++ b/federation/tests/conftest.py
@@ -2,9 +2,9 @@ from unittest.mock import Mock
 
 import pytest
 
-from federation.entities.diaspora.entities import DiasporaPost
+# noinspection PyUnresolvedReferences
+from federation.tests.fixtures.diaspora import *
 from federation.tests.fixtures.keys import get_dummy_private_key
-from federation.tests.fixtures.payloads import DIASPORA_PUBLIC_PAYLOAD
 
 
 @pytest.fixture(autouse=True)
@@ -21,16 +21,6 @@ def disable_network_calls(monkeypatch):
             pass
 
     monkeypatch.setattr("requests.get", Mock(return_value=MockResponse))
-
-
-@pytest.fixture
-def diaspora_public_payload():
-    return DIASPORA_PUBLIC_PAYLOAD
-
-
-@pytest.fixture
-def diasporapost():
-    return DiasporaPost()
 
 
 @pytest.fixture

--- a/federation/tests/entities/diaspora/test_entities.py
+++ b/federation/tests/entities/diaspora/test_entities.py
@@ -110,6 +110,42 @@ class TestEntitiesConvertToXML:
         assert etree.tostring(result).decode("utf-8") == converted
 
 
+class TestEntityAttributes:
+    def test_comment_ids(self, diasporacomment):
+        assert diasporacomment.id == "diaspora://handle/comment/guid"
+        assert not diasporacomment.target_id
+
+    def test_contact_ids(self, diasporacontact):
+        assert not diasporacontact.id
+        assert not diasporacontact.target_id
+
+    def test_like_ids(self, diasporalike):
+        assert diasporalike.id == "diaspora://handle/like/guid"
+        assert not diasporalike.target_id
+
+    def test_post_ids(self, diasporapost):
+        assert diasporapost.id == "diaspora://handle/status_message/guid"
+        assert not diasporapost.target_id
+
+    def test_profile_ids(self, diasporaprofile):
+        assert diasporaprofile.id == "diaspora://bob@example.com/profile/"
+        assert not diasporaprofile.target_id
+
+    def test_request_ids(self, diasporarequest):
+        assert not diasporarequest.id
+        assert not diasporarequest.target_id
+
+    def test_reshare_ids(self, diasporareshare):
+        assert diasporareshare.id == "diaspora://%s/reshare/%s" % (diasporareshare.handle, diasporareshare.guid)
+        assert diasporareshare.target_id == "diaspora://%s/status_message/%s" % (
+            diasporareshare.target_handle, diasporareshare.target_guid
+        )
+
+    def test_retraction_ids(self, diasporaretraction):
+        assert not diasporaretraction.id
+        assert not diasporaretraction.target_id
+
+
 class TestDiasporaProfileFillExtraAttributes:
     def test_raises_if_no_handle(self):
         attrs = {"foo": "bar"}

--- a/federation/tests/fixtures/diaspora.py
+++ b/federation/tests/fixtures/diaspora.py
@@ -1,0 +1,68 @@
+import pytest
+
+from federation.entities.diaspora.entities import (
+    DiasporaPost, DiasporaComment, DiasporaLike, DiasporaRequest, DiasporaProfile, DiasporaRetraction,
+    DiasporaContact, DiasporaReshare,
+)
+from federation.tests.factories.entities import ShareFactory
+from federation.tests.fixtures.payloads import DIASPORA_PUBLIC_PAYLOAD
+
+__all__ = ("diasporacomment", "diasporacontact", "diasporalike", "diasporapost", "diasporaprofile",
+           "diasporareshare", "diasporarequest", "diasporaretraction", "diaspora_public_payload")
+
+
+@pytest.fixture
+def diaspora_public_payload():
+    return DIASPORA_PUBLIC_PAYLOAD
+
+
+@pytest.fixture
+def diasporacomment():
+    return DiasporaComment(
+        raw_content="raw_content", guid="guid", target_guid="target_guid", handle="handle",
+        signature="signature"
+    )
+
+
+@pytest.fixture
+def diasporacontact():
+    return DiasporaContact(handle="alice@example.com", target_handle="bob@example.org", following=True)
+
+
+@pytest.fixture
+def diasporalike():
+    return DiasporaLike(guid="guid", target_guid="target_guid", handle="handle", signature="signature")
+
+
+@pytest.fixture
+def diasporapost():
+    return DiasporaPost(
+        raw_content="raw_content", guid="guid", handle="handle", public=True,
+        provider_display_name="Socialhome"
+    )
+
+
+@pytest.fixture
+def diasporaprofile():
+    return DiasporaProfile(
+        handle="bob@example.com", raw_content="foobar", name="Bob Bobertson", public=True,
+        tag_list=["socialfederation", "federation"], image_urls={
+            "large": "urllarge", "medium": "urlmedium", "small": "urlsmall"
+        }
+    )
+
+
+@pytest.fixture
+def diasporareshare():
+    base_entity = ShareFactory()
+    return DiasporaReshare.from_base(base_entity)
+
+
+@pytest.fixture
+def diasporarequest():
+    return DiasporaRequest(handle="bob@example.com", target_handle="alice@example.com", relationship="following")
+
+
+@pytest.fixture
+def diasporaretraction():
+    return DiasporaRetraction(handle="bob@example.com", target_guid="x" * 16, entity_type="Post")

--- a/federation/tests/fixtures/keys.py
+++ b/federation/tests/fixtures/keys.py
@@ -1,6 +1,5 @@
 from Crypto.PublicKey import RSA
 
-
 PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\n" \
               "MIIEogIBAAKCAQEAiY2JBgMV90ULt0btku198l6wGuzn3xCcHs+eBZHL2C+XWRA3\n" \
               "BVDThSBj19dKXehfDphQ5u/Omfm76ImajEPHGBiYtZT7AgcO15zvm+JCpbREbdOV\n" \
@@ -28,6 +27,44 @@ PRIVATE_KEY = "-----BEGIN RSA PRIVATE KEY-----\n" \
               "t/b5Jw+yQVBqNkfJwOMykCxcYs4IEuJelbOYSCp3GmW014nDxYbe5y1Q40drdTro\n" \
               "w6Y5FnjFw022w+M3exyH6ZtxcmG6buDbp2F/SPD/FnYy5IFCDig=\n" \
               "-----END RSA PRIVATE KEY-----"
+
+# Not related to above private key
+PUBKEY = "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuCfU1G5X+3O6vPdSz6QY\nSFbgdbv3KPv" \
+         "xHi8tRmlyOLdLt5i1eqsy2WCW1iYNijiCL7OfbrvymBQxe3GA9S64\nVuavwzQ8nO7nzpNMqxY5tBXsBM1lECCHDOvm5dzINXWT9Sg7P1" \
+         "8iIxE/2wQEgMUL\nAeVbJtAriXM4zydL7c91agFMJu1aHp0lxzoH8I13xzUetGMutR1tbcfWvoQvPAoU\n89uAz5j/DFMhWrkVEKGeWt1" \
+         "YtHMmJqpYqR6961GDlwRuUsOBsLgLLVohzlBsTBSn\n3580o2E6G3DEaX0Az9WB9ylhNeV/L/PP3c5htpEyoPZSy1pgtut6TRYQwC8wns" \
+         "qO\nbVIbFBkrKoaRDyVCnpMuKdDNLZqOOfhzas+SWRAby6D8VsXpPi/DpeS9XkX0o/uH\nJ9N49GuYMSUGC8gKtaddD13pUqS/9rpSvLD" \
+         "rrDQe5Lhuyusgd28wgEAPCTmM3pEt\nQnlxEeEmFMIn3OBLbEDw5TFE7iED0z7a4dAkqqz8KCGEt12e1Kz7ujuOVMxJxzk6\nNtwt40Sq" \
+         "EOPcdsGHAA+hqzJnXUihXfmtmFkropaCxM2f+Ha0bOQdDDui5crcV3sX\njShmcqN6YqFzmoPK0XM9P1qC+lfL2Mz6bHC5p9M8/FtcM46" \
+         "hCj1TF/tl8zaZxtHP\nOrMuFJy4j4yAsyVy3ddO69ECAwEAAQ==\n-----END PUBLIC KEY-----\n"
+
+SIGNATURE = "A/vVRxM3V1ceEH1JrnPOaIZGM3gMjw/fnT9TgUh3poI4q9eH95AIoig+3eTA8XFuGvuo0tivxci4e0NJ1VLVkl/aqp8rvBNrRI1RQk" \
+            "n2WVF6zk15Gq6KSia/wyzyiJHGxNGM8oFY4qPfNp6K+8ydUti22J11tVBEvQn+7FPAoloF2Xz1waK48ZZCFs8Rxzj+4jlz1PmuXCnT" \
+            "j7v7GYS1Rb6sdFz4nBSuVk5X8tGOSXIRYxPgmtsDRMRrvDeEK+v3OY6VnT8dLTckS0qCwTRUULub1CGwkz/2mReZk/M1W4EbUnugF5" \
+            "ptslmFqYDYJZM8PA/g89EKVpkx2gaFbsC4KXocWnxHNiue18rrFQ5hMnDuDRiRybLnQkxXbE/HDuLdnognt2S5wRshPoZmhe95v3qq" \
+            "/5nH/GX1D7VmxEEIG9fX+XX+Vh9kzO9bLbwoJZwm50zXxCvrLlye/2JU5Vd2Hbm4aMuAyRAZiLS/EQcBlsts4DaFu4txe60HbXSh6n" \
+            "qNofGkusuzZnCd0VObOpXizrI8xNQzZpjJEB5QqE2gbCC2YZNdOS0eBGXw42dAXa/QV3jZXGES7DdQlqPqqT3YjcMFLiRrWQR8cl4h" \
+            "JIBRpV5piGyLmMMKYrWu7hQSrdRAEL3K6mNZZU6/yoG879LjtQbVwaFGPeT29B4zBE97FIo="
+
+SIGNATURE2 = "Xla/AlirMihx72hehGMgpKILRUA2ZkEhFgVc65sl80iN+F62yQdSikGyUQVL+LaGNUgmzgK0zEahamfaMFep/9HE2FWuXlTCM+ZXx" \
+             "OhGWUnjkGW9vi41/Turm7ALzaJoFm1f3Iv4nh1sRD1jySzlZvYwrq4LwmgZ8r0M+Q6xUSIIJfgS8Zjmp43strKo28vKT+DmUKu9Fg" \
+             "jZWjW3S8WPPJFO0UqA0b1UQspmNLZOVxsNpa0OCM1pofJvT09n6xG+byV30Bed27Kw+D3fzfYq5xvohyeCyliTq8LHnOykecki3Y2" \
+             "Pvl1qsxxBehlwc/WH8yIUiwC2Du6zY61tN3LGgMAoIFl40Roo1z/I7YfOy4ZCukOGqqyiLdjoXxIVQqqsPtKsrVXS+A9OQ+sVESgw" \
+             "f8jeEIw/KXLVB/aEyrZJXQR1pBfqkOTCSnAfZVBSjJyxhanS/8iGmnRV5zz3auYMLR9aA8QHjV/VZOj0Bxhuba9VIzJlY9XoUt5Vs" \
+             "h3uILJM3uVJzSjlZV+Jw3O+NdQFnZyh7m1+eJUMQJ8i0Sr3sMLsdb9me/I0HueXCa5eBHAoTtAyQgS4uN4NMhvpqrB/lQCx7pqnkt" \
+             "xiCO/bUEZONQjWrvJT+EfD+I0UMFtPFiGDzJ0yi0Ah7LxSTGEGPFZHH5RgsJA8lJwGMCUtc9Cpy8A="
+
+SIGNATURE3 = "hVdLwsWXe6yVy88m9H1903+Bj/DjSGsYL+ZIpEz+G6u/aVx6QfsvnWHzasjqN8SU+brHfL0c8KrapWcACO+jyCuXlHMZb9zKmJkHR" \
+             "FSOiprCJ3tqNpv/4MIa9CXu0YDqnLHBSyxS01luKw3EqgpWPQdYcqDpOkjjTOq45dQC0PGHA/DXjP7LBptV9AwW200LIcL5Li8tDU" \
+             "a8VSQybspDDfDpXU3+Xl5tJIBVS4ercPczp5B39Cwne4q2gyj/Y5RdIoX5RMqmFhfucw1he38T1oRC9AHTJqj4CBcDt7gc6jPHuzk" \
+             "N7u1eUf0IK3+KTDKsCkkoHcGaoxT+NeWcS8Ki1A=="
+
+XML = "<comment><guid>0dd40d800db1013514416c626dd55703</guid><parent_guid>69ab2b83-aa69-4456-ad0a-dd669" \
+      "7f54714</parent_guid><text>Woop Woop</text><diaspora_handle>jaywink@iliketoast.net</diaspora_handle></comment>"
+
+XML2 = "<comment><guid>d728fe501584013514526c626dd55703</guid><parent_guid>d641bd35-8142-414e-a12d-f956cc2c1bb9" \
+       "</parent_guid><text>What about the mystical problem with &#x1F44D; (pt2 with more logging)</text>" \
+       "<diaspora_handle>jaywink@iliketoast.net</diaspora_handle></comment>"
 
 
 def get_dummy_private_key():

--- a/federation/tests/protocols/diaspora/test_signatures.py
+++ b/federation/tests/protocols/diaspora/test_signatures.py
@@ -1,44 +1,7 @@
 from lxml import etree
 
-from federation.protocols.diaspora.signatures import verify_relayable_signature, create_relayable_signature
-from federation.tests.fixtures.keys import get_dummy_private_key
-
-XML = "<comment><guid>0dd40d800db1013514416c626dd55703</guid><parent_guid>69ab2b83-aa69-4456-ad0a-dd669" \
-      "7f54714</parent_guid><text>Woop Woop</text><diaspora_handle>jaywink@iliketoast.net</diaspora_handle></comment>"
-
-XML2 = "<comment><guid>d728fe501584013514526c626dd55703</guid><parent_guid>d641bd35-8142-414e-a12d-f956cc2c1bb9" \
-       "</parent_guid><text>What about the mystical problem with &#x1F44D; (pt2 with more logging)</text>" \
-       "<diaspora_handle>jaywink@iliketoast.net</diaspora_handle></comment>"
-
-SIGNATURE = "A/vVRxM3V1ceEH1JrnPOaIZGM3gMjw/fnT9TgUh3poI4q9eH95AIoig+3eTA8XFuGvuo0tivxci4e0NJ1VLVkl/aqp8rvBNrRI1RQk" \
-            "n2WVF6zk15Gq6KSia/wyzyiJHGxNGM8oFY4qPfNp6K+8ydUti22J11tVBEvQn+7FPAoloF2Xz1waK48ZZCFs8Rxzj+4jlz1PmuXCnT" \
-            "j7v7GYS1Rb6sdFz4nBSuVk5X8tGOSXIRYxPgmtsDRMRrvDeEK+v3OY6VnT8dLTckS0qCwTRUULub1CGwkz/2mReZk/M1W4EbUnugF5" \
-            "ptslmFqYDYJZM8PA/g89EKVpkx2gaFbsC4KXocWnxHNiue18rrFQ5hMnDuDRiRybLnQkxXbE/HDuLdnognt2S5wRshPoZmhe95v3qq" \
-            "/5nH/GX1D7VmxEEIG9fX+XX+Vh9kzO9bLbwoJZwm50zXxCvrLlye/2JU5Vd2Hbm4aMuAyRAZiLS/EQcBlsts4DaFu4txe60HbXSh6n" \
-            "qNofGkusuzZnCd0VObOpXizrI8xNQzZpjJEB5QqE2gbCC2YZNdOS0eBGXw42dAXa/QV3jZXGES7DdQlqPqqT3YjcMFLiRrWQR8cl4h" \
-            "JIBRpV5piGyLmMMKYrWu7hQSrdRAEL3K6mNZZU6/yoG879LjtQbVwaFGPeT29B4zBE97FIo="
-
-SIGNATURE2 = "Xla/AlirMihx72hehGMgpKILRUA2ZkEhFgVc65sl80iN+F62yQdSikGyUQVL+LaGNUgmzgK0zEahamfaMFep/9HE2FWuXlTCM+ZXx" \
-             "OhGWUnjkGW9vi41/Turm7ALzaJoFm1f3Iv4nh1sRD1jySzlZvYwrq4LwmgZ8r0M+Q6xUSIIJfgS8Zjmp43strKo28vKT+DmUKu9Fg" \
-             "jZWjW3S8WPPJFO0UqA0b1UQspmNLZOVxsNpa0OCM1pofJvT09n6xG+byV30Bed27Kw+D3fzfYq5xvohyeCyliTq8LHnOykecki3Y2" \
-             "Pvl1qsxxBehlwc/WH8yIUiwC2Du6zY61tN3LGgMAoIFl40Roo1z/I7YfOy4ZCukOGqqyiLdjoXxIVQqqsPtKsrVXS+A9OQ+sVESgw" \
-             "f8jeEIw/KXLVB/aEyrZJXQR1pBfqkOTCSnAfZVBSjJyxhanS/8iGmnRV5zz3auYMLR9aA8QHjV/VZOj0Bxhuba9VIzJlY9XoUt5Vs" \
-             "h3uILJM3uVJzSjlZV+Jw3O+NdQFnZyh7m1+eJUMQJ8i0Sr3sMLsdb9me/I0HueXCa5eBHAoTtAyQgS4uN4NMhvpqrB/lQCx7pqnkt" \
-             "xiCO/bUEZONQjWrvJT+EfD+I0UMFtPFiGDzJ0yi0Ah7LxSTGEGPFZHH5RgsJA8lJwGMCUtc9Cpy8A="
-
-SIGNATURE3 = "hVdLwsWXe6yVy88m9H1903+Bj/DjSGsYL+ZIpEz+G6u/aVx6QfsvnWHzasjqN8SU+brHfL0c8KrapWcACO+jyCuXlHMZb9zKmJkHR" \
-             "FSOiprCJ3tqNpv/4MIa9CXu0YDqnLHBSyxS01luKw3EqgpWPQdYcqDpOkjjTOq45dQC0PGHA/DXjP7LBptV9AwW200LIcL5Li8tDU" \
-             "a8VSQybspDDfDpXU3+Xl5tJIBVS4ercPczp5B39Cwne4q2gyj/Y5RdIoX5RMqmFhfucw1he38T1oRC9AHTJqj4CBcDt7gc6jPHuzk" \
-             "N7u1eUf0IK3+KTDKsCkkoHcGaoxT+NeWcS8Ki1A=="
-
-PUBKEY = "-----BEGIN PUBLIC KEY-----\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAuCfU1G5X+3O6vPdSz6QY\nSFbgdbv3KPv" \
-         "xHi8tRmlyOLdLt5i1eqsy2WCW1iYNijiCL7OfbrvymBQxe3GA9S64\nVuavwzQ8nO7nzpNMqxY5tBXsBM1lECCHDOvm5dzINXWT9Sg7P1" \
-         "8iIxE/2wQEgMUL\nAeVbJtAriXM4zydL7c91agFMJu1aHp0lxzoH8I13xzUetGMutR1tbcfWvoQvPAoU\n89uAz5j/DFMhWrkVEKGeWt1" \
-         "YtHMmJqpYqR6961GDlwRuUsOBsLgLLVohzlBsTBSn\n3580o2E6G3DEaX0Az9WB9ylhNeV/L/PP3c5htpEyoPZSy1pgtut6TRYQwC8wns" \
-         "qO\nbVIbFBkrKoaRDyVCnpMuKdDNLZqOOfhzas+SWRAby6D8VsXpPi/DpeS9XkX0o/uH\nJ9N49GuYMSUGC8gKtaddD13pUqS/9rpSvLD" \
-         "rrDQe5Lhuyusgd28wgEAPCTmM3pEt\nQnlxEeEmFMIn3OBLbEDw5TFE7iED0z7a4dAkqqz8KCGEt12e1Kz7ujuOVMxJxzk6\nNtwt40Sq" \
-         "EOPcdsGHAA+hqzJnXUihXfmtmFkropaCxM2f+Ha0bOQdDDui5crcV3sX\njShmcqN6YqFzmoPK0XM9P1qC+lfL2Mz6bHC5p9M8/FtcM46" \
-         "hCj1TF/tl8zaZxtHP\nOrMuFJy4j4yAsyVy3ddO69ECAwEAAQ==\n-----END PUBLIC KEY-----\n"
+from federation.protocols.diaspora.signatures import create_relayable_signature, verify_relayable_signature
+from federation.tests.fixtures.keys import PUBKEY, SIGNATURE, SIGNATURE2, SIGNATURE3, XML, XML2, get_dummy_private_key
 
 
 def test_verify_relayable_signature():

--- a/federation/tests/test_fetchers.py
+++ b/federation/tests/test_fetchers.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, Mock
 
-from federation.entities.base import Post
 from federation.fetchers import retrieve_remote_profile, retrieve_remote_content
 
 
@@ -9,9 +8,9 @@ class TestRetrieveRemoteContent:
     def test_calls_diaspora_retrieve_and_parse_content(self, mock_import):
         mock_retrieve = Mock()
         mock_import.return_value = mock_retrieve
-        retrieve_remote_content(Post, "1234@example.com", sender_key_fetcher=sum)
+        retrieve_remote_content("diaspora://user@example.com/status_message/1234", sender_key_fetcher=sum)
         mock_retrieve.retrieve_and_parse_content.assert_called_once_with(
-            Post, "1234@example.com", sender_key_fetcher=sum,
+            "diaspora://user@example.com/status_message/1234", sender_key_fetcher=sum,
         )
 
 

--- a/federation/tests/test_fetchers.py
+++ b/federation/tests/test_fetchers.py
@@ -1,16 +1,24 @@
-# -*- coding: utf-8 -*-
 from unittest.mock import patch, Mock
 
-from federation.fetchers import retrieve_remote_profile
+from federation.entities.base import Post
+from federation.fetchers import retrieve_remote_profile, retrieve_remote_content
 
 
-class TestRetrieveRemoteProfile(object):
+class TestRetrieveRemoteContent:
+    @patch("federation.fetchers.importlib.import_module")
+    def test_calls_diaspora_retrieve_and_parse_content(self, mock_import):
+        mock_retrieve = Mock()
+        mock_import.return_value = mock_retrieve
+        retrieve_remote_content(Post, "1234@example.com", sender_key_fetcher=sum)
+        mock_retrieve.retrieve_and_parse_content.assert_called_once_with(
+            Post, "1234@example.com", sender_key_fetcher=sum,
+        )
+
+
+class TestRetrieveRemoteProfile:
     @patch("federation.fetchers.importlib.import_module")
     def test_calls_diaspora_retrieve_and_parse_profile(self, mock_import):
-        class MockRetrieve(Mock):
-            def retrieve_and_parse_profile(self, handle):
-                return "called with %s" % handle
-
-        mock_retrieve = MockRetrieve()
+        mock_retrieve = Mock()
         mock_import.return_value = mock_retrieve
-        assert retrieve_remote_profile("foo@bar") == "called with foo@bar"
+        retrieve_remote_profile("foo@bar")
+        mock_retrieve.retrieve_and_parse_profile.assert_called_once_with("foo@bar")


### PR DESCRIPTION
The given ID will be fetched using the correct entity class specific remote endpoint, validated to be from the correct author against their public key and then an instance of the entity class will be constructed and returned.

Also related changes and refactoring:

* New Diaspora protocol helper `federation.utils.diaspora.retrieve_and_parse_content`. See notes regarding the high level fetcher above.
* New Diaspora protocol helper `federation.utils.fetch_public_key`. Given a `handle` as a parameter, will fetch the remote profile and return the `public_key` from it.
* Refactoring for Diaspora `MagicEnvelope` class.
* Diaspora procotol receive flow now uses the `MagicEnvelope` class to verify payloads.
* Diaspora protocol receive flow now fetches the sender public key over the network if a `sender_key_fetcher` function is not passed in. Previously an error would be raised.

Closes #103