### PR TITLE
Ensure DiasporaReshare.public is set

### DIFF
--- a/federation/entities/diaspora/entities.py
+++ b/federation/entities/diaspora/entities.py
@@ -268,6 +268,16 @@ class DiasporaReshare(DiasporaEntityMixin, Share):
     """Diaspora Reshare."""
     _tag_name = "reshare"
 
+    @staticmethod
+    def fill_extra_attributes(attributes):
+        """If `public` is missing, add it as True.
+
+        Diaspora removed this from protocol version 0.2.2 so assume all future reshares are public.
+        """
+        if attributes.get("public") is None:
+            attributes["public"] = True
+        return attributes
+
     def to_xml(self):
         element = etree.Element(self._tag_name)
         struct_to_xml(element, [

--- a/federation/tests/entities/diaspora/test_mappers.py
+++ b/federation/tests/entities/diaspora/test_mappers.py
@@ -213,7 +213,7 @@ class TestDiasporaEntityMappersReceive:
         assert entity.provider_display_name == ""
         assert entity.target_handle == "bob@example.com"
         assert entity.target_guid == "a0b53bc029f6013487753131731751e9"
-        assert entity.public is True
+        assert entity.public is False
         assert entity.entity_type == "Post"
 
     def test_message_to_objects_reshare_extra_properties(self):

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -237,10 +237,8 @@ DIASPORA_RESHARE = """
         <author>alice@example.org</author>
         <guid>a0b53e5029f6013487753131731751e9</guid>
         <created_at>2016-07-12T00:36:42Z</created_at>
-        <provider_display_name/>
         <root_author>bob@example.com</root_author>
         <root_guid>a0b53bc029f6013487753131731751e9</root_guid>
-        <public>true</public>
     </reshare>
 """
 
@@ -252,7 +250,7 @@ DIASPORA_RESHARE_LEGACY = """
         <provider_display_name/>
         <root_diaspora_id>bob@example.com</root_diaspora_id>
         <root_guid>a0b53bc029f6013487753131731751e9</root_guid>
-        <public>true</public>
+        <public>false</public>
     </reshare>
 """
 


### PR DESCRIPTION
Diaspora removed 'public' from reshare in protocol version 0.2.2. Since we do support it, when parsing incoming payloads, set it to True if it is missing. Our Share base entity defaults to False.