### PR TITLE
Ensure handle is always lower cased when fetching remote profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@
 
 * Fix fallback to HTTP in the `fetch_document` network helper in the case of `ConnectionError` when trying HTTPS. Thanks @autogestion.
 
+* Ensure `handle` is always lower cased when fetching remote profile using `retrieve_remote_profile`. Warning will be logged if an upper case handle is passed in.
+
 ## [0.14.1] - 2017-08-06
 
 ### Fixed

--- a/federation/fetchers.py
+++ b/federation/fetchers.py
@@ -1,4 +1,7 @@
 import importlib
+import logging
+
+logger = logging.getLogger("federation")
 
 
 def retrieve_remote_content(id, sender_key_fetcher=None):
@@ -29,4 +32,6 @@ def retrieve_remote_profile(handle):
     """
     protocol_name = "diaspora"
     utils = importlib.import_module("federation.utils.%s" % protocol_name)
-    return utils.retrieve_and_parse_profile(handle)
+    if not handle.islower():
+        logger.warning("retrieve_remote_profile - Handle is not lower case! Will use lower case version to continue.")
+    return utils.retrieve_and_parse_profile(handle.lower())

--- a/federation/tests/test_fetchers.py
+++ b/federation/tests/test_fetchers.py
@@ -21,3 +21,10 @@ class TestRetrieveRemoteProfile:
         mock_import.return_value = mock_retrieve
         retrieve_remote_profile("foo@bar")
         mock_retrieve.retrieve_and_parse_profile.assert_called_once_with("foo@bar")
+
+    @patch("federation.fetchers.importlib.import_module")
+    def test_calls_diaspora_retrieve_and_parse_profile__lower_cases_handle_when_needed(self, mock_import):
+        mock_retrieve = Mock()
+        mock_import.return_value = mock_retrieve
+        retrieve_remote_profile("foo@Bar")
+        mock_retrieve.retrieve_and_parse_profile.assert_called_once_with("foo@bar")


### PR DESCRIPTION
Using `retrieve_remote_profile`. Warning will be logged if an upper case handle is passed in.