### PR TITLE
Support fetching new style Diaspora protocol Webfinger (RFC 3033)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,11 @@
 
   * `retrieve_and_parse_content`. See notes regarding the high level fetcher above.
   * `fetch_public_key`. Given a `handle` as a parameter, will fetch the remote profile and return the `public_key` from it.
-  * `parse_diaspora_uri`. Parses a Diaspora URI scheme string, returns either `None` if parsing fails or a `tuple` of `handle`, `entity_type` and `guid`. 
+  * `parse_diaspora_uri`. Parses a Diaspora URI scheme string, returns either `None` if parsing fails or a `tuple` of `handle`, `entity_type` and `guid`.
+  
+* Support fetching new style Diaspora protocol Webfinger (RFC 3033) ([related issue](https://github.com/jaywink/federation/issues/108))
+
+  The legaxy Webfinger is still used as fallback if the new Webfinger is not found. 
 
 ### Changed
 * Refactoring for Diaspora `MagicEnvelope` class.

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -267,3 +267,39 @@ DIASPORA_RESHARE_WITH_EXTRA_PROPERTIES = """
         <entity_type>Comment</entity_type>
     </reshare>
 """
+
+DIASPORA_WEBFINGER_JSON = """{
+  "subject": "acct:alice@example.org",
+  "links": [
+    {
+      "rel": "http://microformats.org/profile/hcard",
+      "type": "text/html",
+      "href": "https://example.org/hcard/users/7dba7ca01d64013485eb3131731751e9"
+    },
+    {
+      "rel": "http://joindiaspora.com/seed_location",
+      "type": "text/html",
+      "href": "https://example.org/"
+    }
+  ]
+}
+"""
+
+DIASPORA_HOSTMETA = """<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Link rel="lrdd" template="https://example.com/webfinger?q={uri}" type="application/xrd+xml"/>
+</XRD>
+"""
+
+DIASPORA_WEBFINGER = """<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Subject>acct:user@server.example</Subject>
+  <Alias>https://server.example/people/0123456789abcdef</Alias>
+  <Link href="https://server.example/hcard/users/0123456789abcdef" rel="http://microformats.org/profile/hcard" type="text/html"/>
+  <Link href="https://server.example" rel="http://joindiaspora.com/seed_location" type="text/html"/>
+  <Link href="0123456789abcdef" rel="http://joindiaspora.com/guid" type="text/html"/>
+  <Link href="https://server.example/u/user" rel="http://webfinger.net/rel/profile-page" type="text/html"/>
+  <Link href="https://server.example/public/user.atom" rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml"/>
+  <Link href="QUJDREVGPT0=" rel="diaspora-public-key" type="RSA"/>
+</XRD>
+"""

--- a/federation/tests/hostmeta/test_generators.py
+++ b/federation/tests/hostmeta/test_generators.py
@@ -5,25 +5,7 @@ import pytest
 
 from federation.hostmeta.generators import generate_host_meta, generate_legacy_webfinger, generate_hcard, \
     SocialRelayWellKnown, NodeInfo, get_nodeinfo_well_known_document
-
-DIASPORA_HOSTMETA = """<?xml version="1.0" encoding="UTF-8"?>
-<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Link rel="lrdd" template="https://example.com/webfinger?q={uri}" type="application/xrd+xml"/>
-</XRD>
-"""
-
-DIASPORA_WEBFINGER = """<?xml version="1.0" encoding="UTF-8"?>
-<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
-  <Subject>acct:user@server.example</Subject>
-  <Alias>https://server.example/people/0123456789abcdef</Alias>
-  <Link href="https://server.example/hcard/users/0123456789abcdef" rel="http://microformats.org/profile/hcard" type="text/html"/>
-  <Link href="https://server.example" rel="http://joindiaspora.com/seed_location" type="text/html"/>
-  <Link href="0123456789abcdef" rel="http://joindiaspora.com/guid" type="text/html"/>
-  <Link href="https://server.example/u/user" rel="http://webfinger.net/rel/profile-page" type="text/html"/>
-  <Link href="https://server.example/public/user.atom" rel="http://schemas.google.com/g/2010#updates-from" type="application/atom+xml"/>
-  <Link href="QUJDREVGPT0=" rel="diaspora-public-key" type="RSA"/>
-</XRD>
-"""
+from federation.tests.fixtures.payloads import DIASPORA_HOSTMETA, DIASPORA_WEBFINGER
 
 
 class TestDiasporaHostMetaGenerator(object):


### PR DESCRIPTION
The legaxy Webfinger is still used as fallback if the new Webfinger is not found.

Refs: #108