### PR TITLE
Enable delivery of new style private messages using Diaspora protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,27 @@
 
 ## [unreleased]
 
+### Added
+
+* Enable generating encrypted JSON payloads with the Diaspora protocol which adds private message support. ([related issue](https://github.com/jaywink/federation/issues/82))
+
+  JSON encrypted payload encryption and decryption is handled by the Diaspora `EncryptedPayload` class.
+
 ### Changed
 
-* Send outbound Diaspora payloads in new format. Remove possibility to generate legacy MagicEnvelope payloads. ([related issue](https://github.com/jaywink/federation/issues/82)) 
+* Send outbound Diaspora payloads in new format. Remove possibility to generate legacy MagicEnvelope payloads. ([related issue](https://github.com/jaywink/federation/issues/82))
 
+* **Backwards incompatible**.  Refactor `handle_send` function
+    
+  Now handle_send high level outbound helper function also allows delivering private payloads using the Diaspora protocol. ([related issue](https://github.com/jaywink/federation/issues/82))
+  
+  The signature has changed. Parameter `recipients` should now be a list of recipients to delivery to. Each recipient should either be an `id` or a tuple of `(id, public key)`. If public key is provided, Diaspora protocol delivery will be made as an encrypted private delivery.
+  
+* **Backwards incompatible**. Change `handle_create_payload` function signature.
+
+  Parameter `to_user` is now `to_user_key` and thus instead of an object containing the `key` attribute it should now be an RSA public key object instance. This simplifies things since we only need the key from the user, nothing else.
+
+    
 ## [0.15.0] - 2018-02-12
 
 ### Added
@@ -35,10 +52,6 @@
 * Support fetching new style Diaspora protocol Webfinger (RFC 3033) ([related issue](https://github.com/jaywink/federation/issues/108))
 
   The legaxy Webfinger is still used as fallback if the new Webfinger is not found. 
-  
-* Enable generating encrypted JSON payloads with the Diaspora protocol which adds private message support. ([related issue](https://github.com/jaywink/federation/issues/82))
-
-  JSON encrypted payload encryption and decryption is handled by the Diaspora `EncryptedPayload` class.
 
 ### Changed
 * Refactoring for Diaspora `MagicEnvelope` class.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@
 * Support fetching new style Diaspora protocol Webfinger (RFC 3033) ([related issue](https://github.com/jaywink/federation/issues/108))
 
   The legaxy Webfinger is still used as fallback if the new Webfinger is not found. 
+  
+* Enable generating encrypted JSON payloads with the Diaspora protocol which adds private message support. ([related issue](https://github.com/jaywink/federation/issues/82))
+
+  JSON encrypted payload encryption and decryption is handled by the Diaspora `EncryptedPayload` class.
 
 ### Changed
 * Refactoring for Diaspora `MagicEnvelope` class.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -109,6 +109,7 @@ Diaspora
 .. autofunction:: federation.utils.diaspora.fetch_public_key
 .. autofunction:: federation.utils.diaspora.get_fetch_content_endpoint
 .. autofunction:: federation.utils.diaspora.get_public_endpoint
+.. autofunction:: federation.utils.diaspora.get_private_endpoint
 .. autofunction:: federation.utils.diaspora.parse_diaspora_uri
 .. autofunction:: federation.utils.diaspora.parse_profile_from_hcard
 .. autofunction:: federation.utils.diaspora.retrieve_and_parse_content

--- a/federation/outbound.py
+++ b/federation/outbound.py
@@ -1,17 +1,17 @@
 from federation.entities.diaspora.mappers import get_outbound_entity
 from federation.protocols.diaspora.protocol import Protocol
-from federation.utils.diaspora import get_public_endpoint
+from federation.utils.diaspora import get_public_endpoint, get_private_endpoint
 from federation.utils.network import send_document
 
 
-def handle_create_payload(entity, author_user, to_user=None, parent_user=None):
+def handle_create_payload(entity, author_user, to_user_key=None, parent_user=None):
     """Create a payload with the correct protocol.
 
     Any given user arguments must have ``private_key`` and ``handle`` attributes.
 
     :arg entity: Entity object to send. Can be a base entity or a protocol specific one.
     :arg author_user: User authoring the object.
-    :arg to_user: Profile entry to send to (required for non-public content)
+    :arg to_user_key: Public key of user private payload is being sent to, required for private payloads.
     :arg parent_user: (Optional) User object of the parent object, if there is one. This must be given for the
                       Diaspora protocol if a parent object exists, so that a proper ``parent_author_signature`` can
                       be generated. If given, the payload will be sent as this user.
@@ -23,7 +23,7 @@ def handle_create_payload(entity, author_user, to_user=None, parent_user=None):
     if parent_user:
         outbound_entity.sign_with_parent(parent_user.private_key)
     send_as_user = parent_user if parent_user else author_user
-    data = protocol.build_send(entity=outbound_entity, from_user=send_as_user, to_user=to_user)
+    data = protocol.build_send(entity=outbound_entity, from_user=send_as_user, to_user_key=to_user_key)
     return data
 
 
@@ -33,32 +33,62 @@ def handle_send(entity, author_user, recipients=None, parent_user=None):
     Using this we will build a list of payloads per protocol, after resolving any that need to be guessed or
     looked up over the network. After that, each recipient will get the generated protocol payload delivered.
 
-    NOTE! This will not (yet) support Diaspora limited messages - `handle_create_payload` above should be directly
-    called instead and payload sent with `federation.utils.network.send_document`.
-
     Any given user arguments must have ``private_key`` and ``handle`` attributes.
 
     :arg entity: Entity object to send. Can be a base entity or a protocol specific one.
     :arg author_user: User authoring the object.
-    :arg recipients: A list of tuples to delivery to. Tuple contains (recipient handle or domain, protocol or None).
-                     For example ``[("foo@example.com", "diaspora"), ("bar@example.com", None)]``.
+    :arg recipients: A list of recipients to delivery to. Each recipient is a tuple
+                     containing at minimum the "id", optionally "public key" for private deliveries.
+                     Instead of a tuple, for public deliveries the "id" as str is also ok.
+                     If public key is provided, Diaspora protocol delivery will be made as an encrypted
+                     private delivery.
+                     For example
+                     [
+                         ("diaspora://user@domain.tld/profile/zyx", <RSAPublicKey object>),
+                         ("diaspora://user@domain2.tld/profile/xyz", None),
+                         "diaspora://user@domain3.tld/profile/xyz",
+                     ]
     :arg parent_user: (Optional) User object of the parent object, if there is one. This must be given for the
                       Diaspora protocol if a parent object exists, so that a proper ``parent_author_signature`` can
                       be generated. If given, the payload will be sent as this user.
     """
-    payloads = {"diaspora": {"payload": None, "recipients": set()}}
-    # Generate payload per protocol and split recipients to protocols
-    for recipient, protocol in recipients:
-        # TODO currently we only support Diaspora protocol, so no need to guess, just generate the payload
-        if not payloads["diaspora"]["payload"]:
-            payloads["diaspora"]["payload"] = handle_create_payload(entity, author_user, parent_user=parent_user)
-        if "@" in recipient:
-            payloads["diaspora"]["recipients"].add(recipient.split("@")[1])
+    payloads = []
+    public_payloads = {
+        "diaspora": {
+            "payload": None,
+            "urls": set(),
+        },
+    }
+
+    # Generate payloads and collect urls
+    for recipient in recipients:
+        id = recipient[0] if isinstance(recipient, tuple) else recipient
+        public_key = recipient[1] if isinstance(recipient, tuple) and len(recipient) > 1 else None
+        if public_key:
+            # Private payload
+            payload = handle_create_payload(entity, author_user, to_user_key=public_key, parent_user=parent_user)
+            # TODO get_private_endpoint should be imported per protocol
+            url = get_private_endpoint(id)
+            payloads.append({
+                "urls": {url}, "payload": payload,
+            })
         else:
-            payloads["diaspora"]["recipients"].add(recipient)
+            if not public_payloads["diaspora"]["payload"]:
+                public_payloads["diaspora"]["payload"] = handle_create_payload(
+                    entity, author_user, parent_user=parent_user,
+                )
+            # TODO get_public_endpoint should be imported per protocol
+            url = get_public_endpoint(id)
+            public_payloads["diaspora"]["urls"].add(url)
+
+    # Add public payload
+    if public_payloads["diaspora"]["payload"]:
+        payloads.append({
+            "urls": public_payloads["diaspora"]["urls"], "payload": public_payloads["diaspora"]["payload"],
+        })
+
     # Do actual sending
-    for protocol, data in payloads.items():
-        for recipient in data.get("recipients"):
-            # TODO protocol independant url generation by importing named helper under protocol
-            url = get_public_endpoint(recipient)
-            send_document(url, data.get("payload"))
+    for payload in payloads:
+        for url in payload["urls"]:
+            # TODO set content type per protocol above when collecting and use here
+            send_document(url, payload["payload"])

--- a/federation/protocols/diaspora/encrypted.py
+++ b/federation/protocols/diaspora/encrypted.py
@@ -1,7 +1,8 @@
 import json
-from base64 import b64decode
+from base64 import b64decode, b64encode
 
 from Crypto.Cipher import PKCS1_v1_5, AES
+from Crypto.Random import get_random_bytes
 from lxml import etree
 
 
@@ -28,3 +29,33 @@ class EncryptedPayload:
         encrypter = AES.new(key, AES.MODE_CBC, iv)
         content = encrypter.decrypt(encrypted_magic_envelope)
         return etree.fromstring(pkcs7_unpad(content))
+
+    @staticmethod
+    def get_aes_key_json():
+        iv = get_random_bytes(AES.block_size)
+        key = get_random_bytes(32)
+        encrypter = AES.new(key, AES.MODE_CBC, iv)
+        return {
+            "key": b64encode(key),
+            "iv": b64encode(iv),
+        }, encrypter
+
+    @staticmethod
+    def encrypt(payload, public_key):
+        """
+        Encrypt a payload using an encrypted JSON wrapper.
+
+        See: <insert link to docs>
+
+        :param payload: Payload document as a string.
+        :param public_key: Public key of recipient as an RSA object.
+        :return: Encrypted JSON wrapper as dict.
+        """
+        aes_key_json, encrypter = EncryptedPayload.get_aes_key_json()
+        encrypted_me = encrypter.encrypt(payload)
+        cipher = PKCS1_v1_5.new(public_key)
+        aes_key = cipher.encrypt(aes_key_json)
+        return {
+            "aes_key": b64encode(aes_key),
+            "encrypted_magic_envelope": b64encode(encrypted_me),
+        }

--- a/federation/protocols/diaspora/protocol.py
+++ b/federation/protocols/diaspora/protocol.py
@@ -229,13 +229,13 @@ class Protocol(BaseProtocol):
         else:
             return data[0:-data[-1]]
 
-    def build_send(self, entity, from_user, to_user=None, *args, **kwargs):
+    def build_send(self, entity, from_user, to_user_key=None, *args, **kwargs):
         """
         Build POST data for sending out to remotes.
 
         :param entity: The outbound ready entity for this protocol.
         :param from_user: The user sending this payload. Must have ``private_key`` and ``handle`` properties.
-        :param to_user: (Optional) user to send private payload to. Must have ``key`` as receiving user public key.
+        :param to_user_key: (Optional) Public key of user we're sending a private payload to.
         :returns: dict or string depending on if private or public payload.
         """
         if entity.outbound_doc is not None:
@@ -245,6 +245,6 @@ class Protocol(BaseProtocol):
             xml = entity.to_xml()
         me = MagicEnvelope(etree.tostring(xml), private_key=from_user.private_key, author_handle=from_user.handle)
         rendered = me.render()
-        if to_user:
-            return EncryptedPayload.encrypt(rendered, to_user.key)
+        if to_user_key:
+            return EncryptedPayload.encrypt(rendered, to_user_key)
         return rendered

--- a/federation/protocols/diaspora/protocol.py
+++ b/federation/protocols/diaspora/protocol.py
@@ -230,12 +230,21 @@ class Protocol(BaseProtocol):
             return data[0:-data[-1]]
 
     def build_send(self, entity, from_user, to_user=None, *args, **kwargs):
-        """Build POST data for sending out to remotes."""
+        """
+        Build POST data for sending out to remotes.
+
+        :param entity: The outbound ready entity for this protocol.
+        :param from_user: The user sending this payload. Must have ``private_key`` and ``handle`` properties.
+        :param to_user: (Optional) user to send private payload to. Must have ``key`` as receiving user public key.
+        :returns: dict or string depending on if private or public payload.
+        """
         if entity.outbound_doc is not None:
             # Use pregenerated outbound document
             xml = entity.outbound_doc
         else:
             xml = entity.to_xml()
         me = MagicEnvelope(etree.tostring(xml), private_key=from_user.private_key, author_handle=from_user.handle)
-        # TODO wrap if doing encrypted delivery
-        return me.render()
+        rendered = me.render()
+        if to_user:
+            return EncryptedPayload.encrypt(rendered, to_user.key)
+        return rendered

--- a/federation/tests/utils/test_diaspora.py
+++ b/federation/tests/utils/test_diaspora.py
@@ -11,7 +11,7 @@ from federation.utils.diaspora import (
     retrieve_diaspora_hcard, retrieve_diaspora_host_meta, _get_element_text_or_none,
     _get_element_attr_or_none, parse_profile_from_hcard, retrieve_and_parse_profile, retrieve_and_parse_content,
     get_fetch_content_endpoint, fetch_public_key, parse_diaspora_uri,
-    retrieve_and_parse_diaspora_webfinger, parse_diaspora_webfinger)
+    retrieve_and_parse_diaspora_webfinger, parse_diaspora_webfinger, get_public_endpoint, get_private_endpoint)
 
 
 class TestParseDiasporaWebfinger:
@@ -99,7 +99,6 @@ class TestRetrieveAndParseDiasporaWebfinger:
         mock_retrieve.return_value = DiasporaHostMeta(
             webfinger_host="https://localhost"
         ).xrd
-        # mock_fetch.return_value = "document", None, None
         mock_xrd.return_value = "document"
         result = retrieve_and_parse_diaspora_webfinger("bob@localhost")
         calls = [
@@ -110,7 +109,6 @@ class TestRetrieveAndParseDiasporaWebfinger:
             call("https://localhost/webfinger?q=%s" % quote("bob@localhost")),
         ]
         assert calls == mock_fetch.call_args_list
-        # mock_fetch.assert_called_with("https://localhost/webfinger?q=%s" % quote("bob@localhost"))
         assert result == {'hcard_url': None}
 
 
@@ -291,3 +289,19 @@ class TestRetrieveAndParseProfile:
         mock_parse.return_value = mock_profile
         retrieve_and_parse_profile("foo@bar")
         assert mock_profile.validate.called
+
+
+class TestGetPublicEndpoint:
+    def test_correct_endpoint(self):
+        endpoint = get_public_endpoint("diaspora://foobar@example.com/profile/123456")
+        assert endpoint == "https://example.com/receive/public"
+
+
+class TestGetPrivateEndpoint:
+    def test_correct_endpoint(self):
+        endpoint = get_private_endpoint("diaspora://foobar@example.com/profile/123456")
+        assert endpoint == "https://example.com/receive/users/123456"
+
+    def test_raises_value_error_for_non_profile_id(self):
+        with pytest.raises(ValueError):
+            get_private_endpoint("diaspora://foobar@example.com/comment/123456")

--- a/federation/utils/diaspora.py
+++ b/federation/utils/diaspora.py
@@ -235,6 +235,19 @@ def get_fetch_content_endpoint(domain, entity_type, guid):
     return "https://%s/fetch/%s/%s" % (domain, entity_type, guid)
 
 
-def get_public_endpoint(domain):
+def get_public_endpoint(id):
     """Get remote endpoint for delivering public payloads."""
+    handle, _entity_type, _guid = parse_diaspora_uri(id)
+    _username, domain = handle.split("@")
     return "https://%s/receive/public" % domain
+
+
+def get_private_endpoint(id):
+    """Get remote endpoint for delivering private payloads."""
+    handle, entity_type, guid = parse_diaspora_uri(id)
+    if entity_type != "profile":
+        raise ValueError(
+            "Invalid entity type %s to generate private remote endpoint for delivery. Must be 'profile'." % entity_type
+        )
+    _username, domain = handle.split("@")
+    return "https://%s/receive/users/%s" % (domain, guid)

--- a/federation/utils/network.py
+++ b/federation/utils/network.py
@@ -80,7 +80,7 @@ def send_document(url, data, timeout=10, *args, **kwargs):
     Additional ``*args`` and ``**kwargs`` will be passed on to ``requests.post``.
 
     :arg url: Full url to send to, including protocol
-    :arg data: POST data to send (dict)
+    :arg data: Dictionary (will be form-encoded), bytes, or file-like object to send in the body
     :arg timeout: Seconds to wait for response (defaults to 10)
     :returns: Tuple of status code (int or None) and error (exception class instance or None)
     """


### PR DESCRIPTION
* Enable generating encrypted JSON payloads with the Diaspora protocol
  
  This adds possibility for private message support. JSON encrypted payload encryption and decryption is handled by the Diaspora `EncryptedPayload` class.

* Refactor handle_send function

  Now handle_send high level outbound helper function also allows delivering private payloads using the Diaspora protocol.

Refs: #82