### PR TITLE
Switch Diaspora protocol to send new style entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@
 
   Parameter `to_user` is now `to_user_key` and thus instead of an object containing the `key` attribute it should now be an RSA public key object instance. This simplifies things since we only need the key from the user, nothing else.
 
+* Switch Diaspora protocol to send new style entities ([related issue](https://github.com/jaywink/federation/issues/59))
+
+  We've already accepted these on incoming payloads for a long time and so do all the other platforms now, so now we always send out entities with the new property names. This can break federation with really old servers that don't understand these keys yet. 
+
 ### Fixed
 
 * Change unquote method used when preparing Diaspora XML payloads for verification ([related issue](https://github.com/jaywink/federation/issues/115))

--- a/federation/entities/diaspora/entities.py
+++ b/federation/entities/diaspora/entities.py
@@ -117,7 +117,7 @@ class DiasporaComment(DiasporaRelayableMixin, Comment):
             {"author_signature": self.signature},
             {"parent_author_signature": self.parent_signature},
             {"text": self.raw_content},
-            {"diaspora_handle": self.handle},
+            {"author": self.handle},
             {"created_at": format_dt(self.created_at)},
         ])
         return element
@@ -131,9 +131,9 @@ class DiasporaPost(DiasporaEntityMixin, Post):
         """Convert to XML message."""
         element = etree.Element(self._tag_name)
         struct_to_xml(element, [
-            {"raw_message": self.raw_content},
+            {"text": self.raw_content},
             {"guid": self.guid},
-            {"diaspora_handle": self.handle},
+            {"author": self.handle},
             {"public": "true" if self.public else "false"},
             {"created_at": format_dt(self.created_at)},
             {"provider_display_name": self.provider_display_name},
@@ -150,13 +150,13 @@ class DiasporaLike(DiasporaRelayableMixin, Reaction):
         """Convert to XML message."""
         element = etree.Element(self._tag_name)
         struct_to_xml(element, [
-            {"target_type": "Post"},
+            {"parent_type": "Post"},
             {"guid": self.guid},
             {"parent_guid": self.target_guid},
             {"author_signature": self.signature},
             {"parent_author_signature": self.parent_signature},
             {"positive": "true"},
-            {"diaspora_handle": self.handle},
+            {"author": self.handle},
         ])
         return element
 
@@ -203,7 +203,7 @@ class DiasporaProfile(DiasporaEntityMixin, Profile):
         """Convert to XML message."""
         element = etree.Element(self._tag_name)
         struct_to_xml(element, [
-            {"diaspora_handle": self.handle},
+            {"author": self.handle},
             {"first_name": self.name},
             {"last_name": ""},  # Not used in Diaspora modern profiles
             {"image_url": self.image_urls["large"]},
@@ -289,7 +289,7 @@ class DiasporaReshare(DiasporaEntityMixin, Share):
             {"provider_display_name": self.provider_display_name},
             {"public": "true" if self.public else "false"},
             # Some of our own not in Diaspora protocol
-            {"raw_content": self.raw_content},
+            {"text": self.raw_content},
             {"entity_type": self.entity_type},
         ])
         return element

--- a/federation/tests/entities/diaspora/test_entities.py
+++ b/federation/tests/entities/diaspora/test_entities.py
@@ -24,8 +24,8 @@ class TestEntitiesConvertToXML:
         assert result.tag == "status_message"
         assert len(result.find("created_at").text) > 0
         result.find("created_at").text = ""  # timestamp makes testing painful
-        converted = b"<status_message><raw_message>raw_content</raw_message><guid>guid</guid>" \
-                    b"<diaspora_handle>handle</diaspora_handle><public>true</public><created_at>" \
+        converted = b"<status_message><text>raw_content</text><guid>guid</guid>" \
+                    b"<author>handle</author><public>true</public><created_at>" \
                     b"</created_at><provider_display_name>Socialhome</provider_display_name></status_message>"
         assert etree.tostring(result) == converted
 
@@ -40,7 +40,7 @@ class TestEntitiesConvertToXML:
         result.find("created_at").text = ""  # timestamp makes testing painful
         converted = b"<comment><guid>guid</guid><parent_guid>target_guid</parent_guid>" \
                     b"<author_signature>signature</author_signature><parent_author_signature>" \
-                    b"</parent_author_signature><text>raw_content</text><diaspora_handle>handle</diaspora_handle>" \
+                    b"</parent_author_signature><text>raw_content</text><author>handle</author>" \
                     b"<created_at></created_at></comment>"
         assert etree.tostring(result) == converted
 
@@ -48,9 +48,9 @@ class TestEntitiesConvertToXML:
         entity = DiasporaLike(guid="guid", target_guid="target_guid", handle="handle", signature="signature")
         result = entity.to_xml()
         assert result.tag == "like"
-        converted = b"<like><target_type>Post</target_type><guid>guid</guid><parent_guid>target_guid</parent_guid>" \
+        converted = b"<like><parent_type>Post</parent_type><guid>guid</guid><parent_guid>target_guid</parent_guid>" \
                     b"<author_signature>signature</author_signature><parent_author_signature>" \
-                    b"</parent_author_signature><positive>true</positive><diaspora_handle>handle</diaspora_handle>" \
+                    b"</parent_author_signature><positive>true</positive><author>handle</author>" \
                     b"</like>"
         assert etree.tostring(result) == converted
 
@@ -71,7 +71,7 @@ class TestEntitiesConvertToXML:
         )
         result = entity.to_xml()
         assert result.tag == "profile"
-        converted = b"<profile><diaspora_handle>bob@example.com</diaspora_handle>" \
+        converted = b"<profile><author>bob@example.com</author>" \
                     b"<first_name>Bob Bobertson</first_name><last_name></last_name><image_url>urllarge</image_url>" \
                     b"<image_url_small>urlsmall</image_url_small><image_url_medium>urlmedium</image_url_medium>" \
                     b"<gender></gender><bio>foobar</bio><location></location><searchable>true</searchable>" \
@@ -102,7 +102,7 @@ class TestEntitiesConvertToXML:
         result.find("created_at").text = ""  # timestamp makes testing painful
         converted = "<reshare><author>%s</author><guid>%s</guid><created_at></created_at><root_author>%s" \
                     "</root_author><root_guid>%s</root_guid><provider_display_name>%s</provider_display_name>" \
-                    "<public>%s</public><raw_content>%s</raw_content><entity_type>%s</entity_type></reshare>" % (
+                    "<public>%s</public><text>%s</text><entity_type>%s</entity_type></reshare>" % (
                         entity.handle, entity.guid, entity.target_handle, entity.target_guid,
                         entity.provider_display_name, "true" if entity.public else "false", entity.raw_content,
                         entity.entity_type,

--- a/federation/tests/entities/diaspora/test_utils.py
+++ b/federation/tests/entities/diaspora/test_utils.py
@@ -29,8 +29,8 @@ class TestGetFullXMLRepresentation:
         entity = Post()
         document = get_full_xml_representation(entity, "")
         document = re.sub(r"<created_at>.*</created_at>", "", document)  # Dates are annoying to compare
-        assert document == "<XML><post><status_message><raw_message></raw_message><guid></guid>" \
-                           "<diaspora_handle></diaspora_handle><public>false</public>" \
+        assert document == "<XML><post><status_message><text></text><guid></guid>" \
+                           "<author></author><public>false</public>" \
                            "<provider_display_name></provider_display_name></status_message></post></XML>"
 
 


### PR DESCRIPTION
We've already accepted these on incoming payloads for a long time and so do all the other platforms now, so now we always send out entities with the new property names. This can break federation with really old servers that don't understand these keys yet.

Closes #59