### PR TITLE
Add fetching of IP and country

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@
 
 * Add NodeInfo2 generator and Django view. See documentation for details. ([related issue](https://github.com/jaywink/federation/issues/32))
 
+* Added new network utilities to fetch IP and country information from a host.
+
+  The country information is fetched using the free `ip-api.com` service. NOTE! This service is rate limited to 150 requests per minute and requires a paid plan for commercial usage. Please make sure to respect the terms.
+  
+  Country information is automatically fetched when using the NodeInfo, NodeInfo2 and StatisticsJSON parsers.
+
 ### Changed
 
 * Send outbound Diaspora payloads in new format. Remove possibility to generate legacy MagicEnvelope payloads. ([related issue](https://github.com/jaywink/federation/issues/82))

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -177,7 +177,9 @@ Diaspora
 Network
 .......
 
+.. autofunction:: federation.utils.network.fetch_country_by_ip
 .. autofunction:: federation.utils.network.fetch_document
+.. autofunction:: federation.utils.network.fetch_host_ip_and_country
 .. autofunction:: federation.utils.network.send_document
 
 

--- a/federation/tests/hostmeta/test_parsers.py
+++ b/federation/tests/hostmeta/test_parsers.py
@@ -1,11 +1,13 @@
 import json
+from unittest.mock import patch
 
 from federation.hostmeta.parsers import parse_nodeinfo_document, parse_nodeinfo2_document, parse_statisticsjson_document
 from federation.tests.fixtures.hostmeta import NODEINFO2_10_DOC, NODEINFO_10_DOC, NODEINFO_20_DOC, STATISTICS_JSON_DOC
 
 
+@patch('federation.hostmeta.parsers.fetch_host_ip_and_country', return_value=("", ""))
 class TestParseNodeInfoDocument:
-    def test_parse_nodeinfo_10_document(self):
+    def test_parse_nodeinfo_10_document(self, mock_ip):
         result = parse_nodeinfo_document(json.loads(NODEINFO_10_DOC), 'iliketoast.net')
         assert result == {
             'organization': {
@@ -46,7 +48,7 @@ class TestParseNodeInfoDocument:
             },
         }
 
-    def test_parse_nodeinfo_20_document(self):
+    def test_parse_nodeinfo_20_document(self, mock_ip):
         result = parse_nodeinfo_document(json.loads(NODEINFO_20_DOC), 'iliketoast.net')
         assert result == {
             'organization': {
@@ -88,8 +90,9 @@ class TestParseNodeInfoDocument:
         }
 
 
+@patch('federation.hostmeta.parsers.fetch_host_ip_and_country', return_value=("", ""))
 class TestParseNodeInfo2Document:
-    def test_parse_nodeinfo2_10_document(self):
+    def test_parse_nodeinfo2_10_document(self, mock_ip):
         result = parse_nodeinfo2_document(json.loads(NODEINFO2_10_DOC), 'example.com')
         assert result == {
             'organization': {
@@ -122,8 +125,9 @@ class TestParseNodeInfo2Document:
         }
 
 
+@patch('federation.hostmeta.parsers.fetch_host_ip_and_country', return_value=("", ""))
 class TestParseStatisticsJSONDocument:
-    def test_parse_statisticsjson_document(self):
+    def test_parse_statisticsjson_document(self, mock_ip):
         result = parse_statisticsjson_document(json.loads(STATISTICS_JSON_DOC), 'example.com')
         assert result == {
             'organization': {


### PR DESCRIPTION
Network utils has a method `fetch_host_ip_and_country` which will
fetch both. The country fetching uses the `ip-api.com` free service
to resolve country information.