### PR TITLE
Extract mentions from Diaspora payloads that have text content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 
   The country information is fetched using the free `ipdata.co` service. NOTE! This service is rate limited to 1500 requests per day.
   
+* Extract mentions from Diaspora payloads that have text content. The mentions will be available in the entity as `_mentions` which is a set of Diaspora ID's in URI format.
+  
 ### Changed
 
 * Send outbound Diaspora payloads in new format. Remove possibility to generate legacy MagicEnvelope payloads. ([related issue](https://github.com/jaywink/federation/issues/82))

--- a/federation/entities/base.py
+++ b/federation/entities/base.py
@@ -23,6 +23,7 @@ class BaseEntity:
     def __init__(self, *args, **kwargs):
         self._required = []
         self._children = []
+        self._mentions = set()
         for key, value in kwargs.items():
             if hasattr(self, key):
                 setattr(self, key, value)
@@ -30,6 +31,9 @@ class BaseEntity:
                 warnings.warn("%s.__init__ got parameter %s which this class does not support - ignoring." % (
                     self.__class__.__name__, key
                 ))
+
+    def extract_mentions(self):
+        return set()
 
     @property
     def id(self):

--- a/federation/entities/diaspora/mappers.py
+++ b/federation/entities/diaspora/mappers.py
@@ -119,6 +119,8 @@ def element_to_objects(element, sender, sender_key_fetcher=None, user=None):
             "transformed": transformed,
         })
         return []
+    # Extract mentions
+    entity._mentions = entity.extract_mentions()
     # Do child elements
     for child in element:
         entity._children.extend(element_to_objects(child, sender))

--- a/federation/tests/entities/diaspora/test_entities.py
+++ b/federation/tests/entities/diaspora/test_entities.py
@@ -110,6 +110,22 @@ class TestEntitiesConvertToXML:
         assert etree.tostring(result).decode("utf-8") == converted
 
 
+class TestEntitiesExtractMentions:
+    def test_extract_mentions__empty_set_if_no_raw_content(self, diasporacontact):
+        assert diasporacontact.extract_mentions() == set()
+
+    def test_extract_mentions__empty_set_if_no_mentions(self, diasporacomment):
+        assert diasporacomment.extract_mentions() == set()
+
+    def test_extract_mentions__set_contains_mentioned_handles(self, diasporapost):
+        diasporapost.raw_content = 'yeye @{Jason Robinson 🐍🍻; jaywink@jasonrobinson.me} foobar ' \
+                                   '@{bar; foo@example.com}'
+        assert diasporapost.extract_mentions() == {
+            'diaspora://jaywink@jasonrobinson.me/profile/',
+            'diaspora://foo@example.com/profile/',
+        }
+
+
 class TestEntityAttributes:
     def test_comment_ids(self, diasporacomment):
         assert diasporacomment.id == "diaspora://handle/comment/guid"
@@ -223,7 +239,7 @@ class TestDiasporaRelayableMixin:
                                                       b'TsLM+Yw==</parent_author_signature></comment>'
 
     @patch("federation.entities.diaspora.mappers.DiasporaComment._validate_signatures")
-    def test_sign_with_parent(self, mock_validate):
+    def test_sign_with_parent__calls_to_xml(self, mock_validate):
         entity = DiasporaComment()
         with patch.object(entity, "to_xml") as mock_to_xml:
             entity.sign_with_parent(get_dummy_private_key())

--- a/federation/tests/entities/diaspora/test_mappers.py
+++ b/federation/tests/entities/diaspora/test_mappers.py
@@ -17,7 +17,7 @@ from federation.tests.fixtures.payloads import (
     DIASPORA_REQUEST, DIASPORA_PROFILE, DIASPORA_POST_INVALID, DIASPORA_RETRACTION,
     DIASPORA_POST_WITH_PHOTOS, DIASPORA_POST_LEGACY_TIMESTAMP, DIASPORA_POST_LEGACY, DIASPORA_CONTACT,
     DIASPORA_LEGACY_REQUEST_RETRACTION, DIASPORA_POST_WITH_PHOTOS_2, DIASPORA_PROFILE_EMPTY_TAGS, DIASPORA_RESHARE,
-    DIASPORA_RESHARE_WITH_EXTRA_PROPERTIES, DIASPORA_RESHARE_LEGACY)
+    DIASPORA_RESHARE_WITH_EXTRA_PROPERTIES, DIASPORA_RESHARE_LEGACY, DIASPORA_POST_SIMPLE_WITH_MENTION)
 
 
 def mock_fill(attributes):
@@ -26,6 +26,12 @@ def mock_fill(attributes):
 
 
 class TestDiasporaEntityMappersReceive:
+    def test_message_to_objects_mentions_are_extracted(self):
+        entities = message_to_objects(DIASPORA_POST_SIMPLE_WITH_MENTION, "alice@alice.diaspora.example.org")
+        assert len(entities) == 1
+        post = entities[0]
+        assert post._mentions == {'diaspora://jaywink@jasonrobinson.me/profile/'}
+
     def test_message_to_objects_simple_post(self):
         entities = message_to_objects(DIASPORA_POST_SIMPLE, "alice@alice.diaspora.example.org")
         assert len(entities) == 1

--- a/federation/tests/fixtures/payloads.py
+++ b/federation/tests/fixtures/payloads.py
@@ -73,6 +73,18 @@ DIASPORA_POST_SIMPLE = """
 """
 
 
+DIASPORA_POST_SIMPLE_WITH_MENTION = """
+    <status_message>
+      <text>((status message)) @{Jason Robinson 🐍🍻; jaywink@jasonrobinson.me}</text>
+      <guid>((guidguidguidguidguidguidguid))</guid>
+      <author>alice@alice.diaspora.example.org</author>
+      <public>false</public>
+      <created_at>2011-07-20T01:36:07Z</created_at>
+      <provider_display_name>Socialhome</provider_display_name>
+    </status_message>
+"""
+
+
 DIASPORA_POST_LEGACY_TIMESTAMP = """
     <status_message>
       <text>((status message))</text>


### PR DESCRIPTION
The mentions will be available in the entity as `_mentions` which is
a set of Diaspora ID's in URI format.